### PR TITLE
Improve anonymization process

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -29,6 +29,8 @@ const config = {
   mailgunDomain: process.env.MAILGUN_DOMAIN,
 
   adminRegistrationAllowed: process.env.ADMIN_REGISTRATION_ALLOWED === 'true',
+
+  anonymizeAfterDays: process.env.ANONYMIZE_AFTER_DAYS || 180,
 };
 
 Object.entries(config).forEach(([key, value]) => {


### PR DESCRIPTION
Closes #13.

This pull request improves the automatic anonymization of old registrations in the following ways:

- Answers to questions are now also redacted in addition to name and email.
- The maximum age of registrations is configurable via environment variable.
- The age is now computed from the event date, or the registration closure date if the event has no date.
    - This ensures registrations are not deleted ahead of time if they are collected long before an event.
    - We may want to investigate further options for this for long-term non-event registrations, if those are desirable.