### PR TITLE
Add URL slugs for events

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,11 @@
+This file contains SQL scripts for migrating data from the Athene-created version of Ilmomasiina.
+
+**Please make full backups of your data before proceeding with this migration.**
+
+## MariaDB/MySQL
+
+```sql
+ALTER TABLE `event` ADD `slug` VARCHAR(255) NOT NULL AFTER `title`;
+UPDATE `event` SET `slug` = CONVERT(`id`, CHAR);
+ALTER TABLE `event` ADD CONSTRAINT UNIQUE (`slug`);
+```

--- a/server/models/event.ts
+++ b/server/models/event.ts
@@ -12,6 +12,7 @@ import { Quota } from './quota';
 export interface EventAttributes {
   id: number;
   title: string;
+  slug: string;
   date: Date;
   registrationStartDate: Date;
   registrationEndDate: Date;
@@ -33,6 +34,7 @@ export interface EventCreationAttributes
 export class Event extends Model<EventAttributes, EventCreationAttributes> implements EventAttributes {
   public id!: number;
   public title!: string;
+  public slug!: string;
   public date!: Date;
   public registrationStartDate!: Date;
   public registrationEndDate!: Date;
@@ -87,6 +89,14 @@ export default function setupEventModel(this: IlmoApplication) {
       title: {
         type: DataTypes.STRING,
         allowNull: false,
+        validate: {
+          notEmpty: true,
+        },
+      },
+      slug: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
         validate: {
           notEmpty: true,
         },

--- a/server/models/event.ts
+++ b/server/models/event.ts
@@ -99,6 +99,7 @@ export default function setupEventModel(this: IlmoApplication) {
         unique: true,
         validate: {
           notEmpty: true,
+          is: /^[A-Za-z0-9_-]+$/,
         },
       },
       date: {

--- a/server/services/admin/event/createEvent.ts
+++ b/server/services/admin/event/createEvent.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { Event } from '../../../models/event';
 import { Question } from '../../../models/question';
 import { Quota } from '../../../models/quota';
-import getEventDetails, { AdminEventGetResponse } from '../../event/getEventDetails';
+import { AdminEventGetResponse, getEventDetailsForAdmin } from '../../event/getEventDetails';
 
 // Attributes included in POST /api/events for Event instances.
 export const adminEventCreateEventAttrs = [
@@ -74,5 +74,5 @@ export default async (data: AdminEventCreateBody): Promise<AdminEventGetResponse
     })
   ));
 
-  return getEventDetails(event.id, true);
+  return getEventDetailsForAdmin(event.id);
 };

--- a/server/services/admin/event/createEvent.ts
+++ b/server/services/admin/event/createEvent.ts
@@ -8,6 +8,7 @@ import getEventDetails, { AdminEventGetResponse } from '../../event/getEventDeta
 // Attributes included in POST /api/events for Event instances.
 export const adminEventCreateEventAttrs = [
   'title',
+  'slug',
   'date',
   'registrationStartDate',
   'registrationEndDate',

--- a/server/services/admin/event/index.ts
+++ b/server/services/admin/event/index.ts
@@ -6,21 +6,21 @@ import { MethodNotAllowed } from '@feathersjs/errors';
 import { Id } from '@feathersjs/feathers';
 
 import { IlmoApplication } from '../../../defs';
-import getEventDetails, { EventGetResponse } from '../../event/getEventDetails';
-import getEventsList, { EventListResponse } from '../../event/getEventsList';
+import { AdminEventGetResponse, getEventDetailsForAdmin } from '../../event/getEventDetails';
+import { AdminEventListResponse, getEventsListForAdmin } from '../../event/getEventsList';
 import createEvent, { AdminEventCreateBody } from './createEvent';
 import deleteEvent from './deleteEvent';
 import updateEvent, { AdminEventUpdateBody } from './updateEvent';
 
-type AdminEventsServiceResponses = EventListResponse | EventGetResponse;
+type AdminEventsServiceResponses = AdminEventListResponse | AdminEventGetResponse;
 
 export class AdminEventsService extends AdapterService<AdminEventsServiceResponses> {
   _find() {
-    return getEventsList(true);
+    return getEventsListForAdmin();
   }
 
   _get(id: Id) {
-    return getEventDetails(Number(id), true);
+    return getEventDetailsForAdmin(Number(id));
   }
 
   _create(data: AdminEventCreateBody) {

--- a/server/services/admin/event/updateEvent.ts
+++ b/server/services/admin/event/updateEvent.ts
@@ -5,7 +5,7 @@ import { Op, Transaction } from 'sequelize';
 import { Event } from '../../../models/event';
 import { Question } from '../../../models/question';
 import { Quota } from '../../../models/quota';
-import getEventDetails, { AdminEventGetResponse } from '../../event/getEventDetails';
+import { AdminEventGetResponse, getEventDetailsForAdmin } from '../../event/getEventDetails';
 import { adminEventCreateEventAttrs, adminEventCreateQuestionAttrs, adminEventCreateQuotaAttrs } from './createEvent';
 
 // Data type definitions for the request body, using attribute lists from createEvent.
@@ -134,5 +134,5 @@ export default async (id: number, data: Partial<AdminEventUpdateBody>): Promise<
     }
   });
 
-  return getEventDetails(id, true);
+  return getEventDetailsForAdmin(id);
 };

--- a/server/services/admin/slug/checkSlugAvailability.ts
+++ b/server/services/admin/slug/checkSlugAvailability.ts
@@ -5,10 +5,6 @@ export interface AdminCheckSlugResponse {
   title: string | null;
 }
 
-/**
- * @param slugOrId Event id if admin === true, slug if admin === false.
- * @param admin Whether or not to return results for the admin view.
- */
 export default async function checkSlugAvailability(slug: string): Promise<AdminCheckSlugResponse> {
   const event = await Event.unscoped().findOne({
     where: {

--- a/server/services/admin/slug/checkSlugAvailability.ts
+++ b/server/services/admin/slug/checkSlugAvailability.ts
@@ -1,0 +1,23 @@
+import { Event } from '../../../models/event';
+
+export interface AdminCheckSlugResponse {
+  id: Event['id'] | null;
+  title: string | null;
+}
+
+/**
+ * @param slugOrId Event id if admin === true, slug if admin === false.
+ * @param admin Whether or not to return results for the admin view.
+ */
+export default async function checkSlugAvailability(slug: string): Promise<AdminCheckSlugResponse> {
+  const event = await Event.unscoped().findOne({
+    where: {
+      slug,
+    },
+    attributes: ['id', 'title'],
+  });
+  return {
+    id: event?.id ?? null,
+    title: event?.title ?? null,
+  };
+}

--- a/server/services/admin/slug/index.ts
+++ b/server/services/admin/slug/index.ts
@@ -1,0 +1,49 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable class-methods-use-this */
+import { AdapterService } from '@feathersjs/adapter-commons';
+import { hooks as authHooks } from '@feathersjs/authentication';
+import { MethodNotAllowed } from '@feathersjs/errors';
+import { Id } from '@feathersjs/feathers';
+
+import { IlmoApplication } from '../../../defs';
+import checkSlugAvailability from './checkSlugAvailability';
+
+type AdminSlugServiceResponses = never;
+
+export class AdminSlugService extends AdapterService<AdminSlugServiceResponses> {
+  _find(): never {
+    throw new MethodNotAllowed('Cannot GET /api/admin/slug');
+  }
+
+  _get(slug: Id) {
+    return checkSlugAvailability(String(slug));
+  }
+
+  _create(): never {
+    throw new MethodNotAllowed('Cannot POST /api/admin/slug');
+  }
+
+  _update(): never {
+    throw new MethodNotAllowed('Cannot PUT /api/admin/slug/ID');
+  }
+
+  _patch(): never {
+    throw new MethodNotAllowed('Cannot PATCH /api/admin/slug/ID');
+  }
+
+  _remove(): never {
+    throw new MethodNotAllowed('Cannot DELETE /api/admin/slug/ID');
+  }
+}
+
+export default function setupAdminSlugService(this: IlmoApplication) {
+  const app = this;
+
+  app.use('/api/admin/slug', new AdminSlugService({}));
+
+  app.service('/api/admin/slug').hooks({
+    before: {
+      all: [authHooks.authenticate('jwt')],
+    },
+  });
+}

--- a/server/services/admin/slug/index.ts
+++ b/server/services/admin/slug/index.ts
@@ -6,9 +6,9 @@ import { MethodNotAllowed } from '@feathersjs/errors';
 import { Id } from '@feathersjs/feathers';
 
 import { IlmoApplication } from '../../../defs';
-import checkSlugAvailability from './checkSlugAvailability';
+import checkSlugAvailability, { AdminCheckSlugResponse } from './checkSlugAvailability';
 
-type AdminSlugServiceResponses = never;
+type AdminSlugServiceResponses = AdminCheckSlugResponse;
 
 export class AdminSlugService extends AdapterService<AdminSlugServiceResponses> {
   _find(): never {

--- a/server/services/event/getEventDetails.ts
+++ b/server/services/event/getEventDetails.ts
@@ -1,4 +1,4 @@
-import { BadRequest, NotFound } from '@feathersjs/errors';
+import { NotFound } from '@feathersjs/errors';
 import _ from 'lodash';
 
 import { Answer } from '../../models/answer';
@@ -119,8 +119,12 @@ export interface AdminEventGetResponse extends Pick<Event, typeof adminEventGetE
 
 export type EventGetResponseType<A extends boolean> = true extends A ? AdminEventGetResponse : EventGetResponse;
 
+/**
+ * @param slugOrId Event id if admin === true, slug if admin === false.
+ * @param admin Whether or not to return results for the admin view.
+ */
 export default async function getEventDetails<A extends boolean>(
-  slug: string, admin: A,
+  slugOrId: string | number, admin: A,
 ): Promise<EventGetResponseType<A>> {
   // Admin queries include internal data such as confirmation email contents
   const eventAttrs = admin ? adminEventGetEventAttrs : eventGetEventAttrs;
@@ -128,11 +132,11 @@ export default async function getEventDetails<A extends boolean>(
   const signupAttrs = admin ? adminEventGetSignupAttrs : eventGetSignupAttrs;
   // Admin queries also show past and draft events.
   const scope = admin ? Event.unscoped() : Event;
+  // Admin queries use ids (so that the slug can be safely edited), user queries use slugs.
+  const where = admin ? { id: slugOrId } : { slug: slugOrId };
 
   const event = await scope.findOne({
-    where: {
-      slug,
-    },
+    where,
     attributes: [...eventAttrs],
     include: [
       // First include all questions (also non-public for the form)

--- a/server/services/event/getEventDetails.ts
+++ b/server/services/event/getEventDetails.ts
@@ -9,8 +9,8 @@ import { Signup } from '../../models/signup';
 
 // Attributes included in GET /api/events/ID for Event instances.
 export const eventGetEventAttrs = [
-  'id',
   'title',
+  'slug',
   'date',
   'registrationStartDate',
   'registrationEndDate',
@@ -26,6 +26,7 @@ export const eventGetEventAttrs = [
 // Attributes included in GET /api/admin/events/ID for Event instances.
 export const adminEventGetEventAttrs = [
   ...eventGetEventAttrs,
+  'id',
   'draft',
   'verificationEmail',
 ] as const;

--- a/server/services/event/getEventDetails.ts
+++ b/server/services/event/getEventDetails.ts
@@ -120,12 +120,8 @@ export interface AdminEventGetResponse extends Pick<Event, typeof adminEventGetE
 export type EventGetResponseType<A extends boolean> = true extends A ? AdminEventGetResponse : EventGetResponse;
 
 export default async function getEventDetails<A extends boolean>(
-  id: number, admin: A,
+  slug: string, admin: A,
 ): Promise<EventGetResponseType<A>> {
-  if (!Number.isSafeInteger(id)) {
-    throw new BadRequest('Invalid id');
-  }
-
   // Admin queries include internal data such as confirmation email contents
   const eventAttrs = admin ? adminEventGetEventAttrs : eventGetEventAttrs;
   // Admin queries include emails and signup IDs
@@ -133,7 +129,10 @@ export default async function getEventDetails<A extends boolean>(
   // Admin queries also show past and draft events.
   const scope = admin ? Event.unscoped() : Event;
 
-  const event = await scope.findByPk(id, {
+  const event = await scope.findOne({
+    where: {
+      slug,
+    },
     attributes: [...eventAttrs],
     include: [
       // First include all questions (also non-public for the form)

--- a/server/services/event/getEventsList.ts
+++ b/server/services/event/getEventsList.ts
@@ -53,7 +53,9 @@ export interface AdminEventListItem extends Pick<Event, typeof adminEventListEve
 
 export type AdminEventListResponse = AdminEventListItem[];
 
-export default async (admin = false): Promise<EventListResponse> => {
+export type EventListResponseType<A extends boolean> = true extends A ? AdminEventListResponse : EventListResponse;
+
+async function getEventsList<A extends boolean>(admin: A): Promise<EventListResponseType<A>> {
   // Admin view also shows draft field.
   const eventAttrs = admin ? adminEventListEventAttrs : eventListEventAttrs;
   // Admin view shows all events, user view only shows future events.
@@ -84,7 +86,7 @@ export default async (admin = false): Promise<EventListResponse> => {
   });
 
   // Convert event list to response
-  const result: EventListResponse = events.map((event) => ({
+  const result: EventListResponseType<A> = events.map((event) => ({
     ..._.pick(event, eventAttrs),
     quota: event.quotas!.map((quota) => ({
       ..._.pick(quota, eventListQuotaAttrs),
@@ -93,4 +95,12 @@ export default async (admin = false): Promise<EventListResponse> => {
   }));
 
   return result;
-};
+}
+
+export default function getEventsListForUser() {
+  return getEventsList(false);
+}
+
+export function getEventsListForAdmin() {
+  return getEventsList(true);
+}

--- a/server/services/event/getEventsList.ts
+++ b/server/services/event/getEventsList.ts
@@ -7,7 +7,7 @@ import { Signup } from '../../models/signup';
 
 // Attributes included in GET /api/events for Event instances.
 export const eventListEventAttrs = [
-  'id',
+  'slug',
   'title',
   'date',
   'registrationStartDate',
@@ -19,6 +19,7 @@ export const eventListEventAttrs = [
 // Attributes included in GET /api/admin/events for Event instances.
 const adminEventListEventAttrs = [
   ...eventListEventAttrs,
+  'id',
   'draft',
 ] as const;
 

--- a/server/services/event/index.ts
+++ b/server/services/event/index.ts
@@ -17,7 +17,7 @@ export class EventsService extends AdapterService<EventsServiceResponses> {
   }
 
   _get(id: Id) {
-    return getEventDetails(String(id), false);
+    return getEventDetails(String(id));
   }
 
   _create(): never {

--- a/server/services/event/index.ts
+++ b/server/services/event/index.ts
@@ -17,7 +17,7 @@ export class EventsService extends AdapterService<EventsServiceResponses> {
   }
 
   _get(id: Id) {
-    return getEventDetails(Number(id), false);
+    return getEventDetails(String(id), false);
   }
 
   _create(): never {

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -5,6 +5,7 @@ import { Service } from '@feathersjs/feathers';
 import { IlmoApplication } from '../defs';
 import adminEvents, { AdminEventsService } from './admin/event';
 import adminSignups, { AdminSignupsService } from './admin/signup';
+import adminSlug, { AdminSlugService } from './admin/slug';
 import authentication from './authentication';
 import event, { EventsService } from './event';
 import signup, { SignupsService } from './signup';
@@ -16,6 +17,7 @@ type WrapAdapter<S> = S extends AdapterService<infer T> ? S & Service<T> : never
 export interface IlmoServices {
   '/api/admin/events': WrapAdapter<AdminEventsService>;
   '/api/admin/signups': WrapAdapter<AdminSignupsService>;
+  '/api/admin/slug': WrapAdapter<AdminSlugService>;
   '/api/authentication': AuthenticationService;
   '/api/events': WrapAdapter<EventsService>;
   '/api/signups': WrapAdapter<SignupsService>;
@@ -28,6 +30,7 @@ export default function setupServices(this: IlmoApplication) {
   app.configure(authentication);
   app.configure(adminEvents);
   app.configure(adminSignups);
+  app.configure(adminSlug);
   app.configure(event);
   app.configure(signup);
   app.configure(user);

--- a/src/api/adminEvents.d.ts
+++ b/src/api/adminEvents.d.ts
@@ -9,6 +9,9 @@ import {
   AdminEventUpdateQuota as _AdminEventUpdateQuota,
 } from '../../server/services/admin/event/updateEvent';
 import {
+  AdminCheckSlugResponse as _AdminCheckSlugResponse,
+} from '../../server/services/admin/slug/checkSlugAvailability';
+import {
   AdminEventGetAnswerItem as _AdminEventGetAnswerItem,
   AdminEventGetQuestionItem as _AdminEventGetQuestionItem,
   AdminEventGetQuotaItem as _AdminEventGetQuotaItem,
@@ -50,4 +53,8 @@ export namespace AdminEvent {
     export type Question = StringifyApi<_AdminEventUpdateQuestion>;
     export type Quota = StringifyApi<_AdminEventUpdateQuota>;
   }
+}
+
+export namespace AdminSlug {
+  export type Check = StringifyApi<_AdminCheckSlugResponse>;
 }

--- a/src/api/adminEvents.d.ts
+++ b/src/api/adminEvents.d.ts
@@ -23,6 +23,8 @@ import {
 import { StringifyApi } from './utils';
 
 export namespace AdminEvent {
+  export type Id = Details['id'];
+
   export type List = StringifyApi<_AdminEventListResponse>;
   export namespace List {
     export type Event = StringifyApi<_AdminEventListItem>;

--- a/src/api/events.d.ts
+++ b/src/api/events.d.ts
@@ -13,7 +13,7 @@ import {
 import { StringifyApi } from './utils';
 
 export namespace Event {
-  export type Id = Details['id'];
+  export type Slug = Details['slug'];
 
   export type Details = StringifyApi<_EventGetResponse>;
   export namespace Details {

--- a/src/components/FieldRow/index.tsx
+++ b/src/components/FieldRow/index.tsx
@@ -9,13 +9,23 @@ type Props = {
   help?: ReactNode;
   required?: boolean;
   alternateError?: string;
+  extraFeedback?: ReactNode;
   checkAlign?: boolean;
   as?: ComponentType<any> | string;
   children?: ReactNode;
 };
 
 export default function FieldRow<P = unknown>({
-  name, label, help, required = false, alternateError, checkAlign, as = Form.Control, children, ...props
+  name,
+  label,
+  help,
+  required = false,
+  alternateError,
+  extraFeedback,
+  checkAlign,
+  as = Form.Control,
+  children,
+  ...props
 }: Props & P) {
   const { errors } = useFormikContext<any>();
 
@@ -34,6 +44,7 @@ export default function FieldRow<P = unknown>({
         <Form.Control.Feedback type="invalid">
           {errors[name] && (alternateError || errors[name])}
         </Form.Control.Feedback>
+        {extraFeedback}
         {help && <Form.Text muted>{help}</Form.Text>}
       </Col>
     </Form.Group>

--- a/src/containers/AppContainer.tsx
+++ b/src/containers/AppContainer.tsx
@@ -36,7 +36,7 @@ const AppContainer = () => (
               />
               <Route
                 exact
-                path={`${PREFIX_URL}/event/:id`}
+                path={`${PREFIX_URL}/event/:slug`}
                 component={SingleEvent}
               />
               <Route

--- a/src/modules/admin/actions.ts
+++ b/src/modules/admin/actions.ts
@@ -1,6 +1,5 @@
 import apiFetch from '../../api';
 import { AdminEvent } from '../../api/adminEvents';
-import { Event } from '../../api/events';
 import { User } from '../../api/users';
 import { DispatchAction, GetState } from '../../store/types';
 import {
@@ -59,7 +58,7 @@ export const getAdminEvents = () => async (dispatch: DispatchAction, getState: G
   }
 };
 
-export const deleteEvent = (id: Event.Id) => async (_dispatch: DispatchAction, getState: GetState) => {
+export const deleteEvent = (id: AdminEvent.Id) => async (_dispatch: DispatchAction, getState: GetState) => {
   const { accessToken } = getState().auth;
 
   try {

--- a/src/modules/editor/actionTypes.ts
+++ b/src/modules/editor/actionTypes.ts
@@ -4,3 +4,5 @@ export const EVENT_LOAD_FAILED = 'editor/EVENT_LOAD_FAILED';
 export const EVENT_SAVING = 'editor/EVENT_SAVING';
 export const EVENT_SAVE_FAILED = 'editor/EVENT_SAVE_FAILED';
 export const EVENT_SAVED = 'editor/EVENT_SAVED';
+export const EVENT_SLUG_CHECKING = 'editor/EVENT_CHECKING';
+export const EVENT_SLUG_CHECKED = 'editor/EVENT_SLUG_CHECKED';

--- a/src/modules/editor/actions.ts
+++ b/src/modules/editor/actions.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import apiFetch from '../../api';
-import { AdminEvent } from '../../api/adminEvents';
+import { AdminEvent, AdminSlug } from '../../api/adminEvents';
 import { Signup } from '../../api/signups';
 import { DispatchAction, GetState } from '../../store/types';
 import {
@@ -9,6 +9,8 @@ import {
   EVENT_LOADED,
   EVENT_SAVE_FAILED,
   EVENT_SAVING,
+  EVENT_SLUG_CHECKED,
+  EVENT_SLUG_CHECKING,
   RESET,
 } from './actionTypes';
 import { EditorEvent } from './types';
@@ -70,6 +72,17 @@ export const loadFailed = () => <const>{
   type: EVENT_LOAD_FAILED,
 };
 
+export const checkingSlugAvailability = () => <const>{
+  type: EVENT_SLUG_CHECKING,
+};
+
+export const slugAvailabilityChecked = (
+  result: AdminSlug.Check | null,
+) => <const>{
+  type: EVENT_SLUG_CHECKED,
+  payload: result,
+};
+
 export const saving = () => <const>{
   type: EVENT_SAVING,
 };
@@ -117,6 +130,18 @@ export const getEvent = (id: AdminEvent.Id | string) => async (dispatch: Dispatc
     dispatch(loaded(response, formData));
   } catch (e) {
     dispatch(loadFailed());
+  }
+};
+
+export const checkSlugAvailability = (slug: string) => async (dispatch: DispatchAction, getState: GetState) => {
+  const { accessToken } = getState().auth;
+  try {
+    const response = await apiFetch(`admin/slug/${slug}`, {
+      accessToken,
+    }) as AdminSlug.Check;
+    dispatch(slugAvailabilityChecked(response));
+  } catch (e) {
+    dispatch(slugAvailabilityChecked(null));
   }
 };
 

--- a/src/modules/editor/actions.ts
+++ b/src/modules/editor/actions.ts
@@ -2,7 +2,6 @@ import moment from 'moment';
 
 import apiFetch from '../../api';
 import { AdminEvent } from '../../api/adminEvents';
-import { Event } from '../../api/events';
 import { Signup } from '../../api/signups';
 import { DispatchAction, GetState } from '../../store/types';
 import {
@@ -68,7 +67,8 @@ const editorEventToServer = (form: EditorEvent): AdminEvent.Update.Body => ({
   })),
 });
 
-export const getEvent = (id: Event.Id | string) => async (dispatch: DispatchAction, getState: GetState) => {
+// TODO remove | string when ids are all strings
+export const getEvent = (id: AdminEvent.Id | string) => async (dispatch: DispatchAction, getState: GetState) => {
   const { accessToken } = getState().auth;
   try {
     const response = await apiFetch(`admin/events/${id}`, { accessToken }) as AdminEvent.Details;
@@ -101,7 +101,7 @@ export const publishNewEvent = (data: EditorEvent) => async (dispatch: DispatchA
 };
 
 export const publishEventUpdate = (
-  id: Event.Id | string, data: EditorEvent,
+  id: AdminEvent.Id, data: EditorEvent,
 ) => async (dispatch: DispatchAction, getState: GetState) => {
   dispatch(saving());
 

--- a/src/modules/editor/actions.ts
+++ b/src/modules/editor/actions.ts
@@ -13,15 +13,56 @@ import {
 } from './actionTypes';
 import { EditorEvent } from './types';
 
+const defaultEvent = (): EditorEvent => ({
+  title: '',
+  slug: '',
+  date: undefined,
+  webpageUrl: '',
+  facebookUrl: '',
+  location: '',
+  description: '',
+  price: '',
+  signupsPublic: false,
+
+  registrationStartDate: undefined,
+  registrationEndDate: undefined,
+
+  openQuotaSize: 0,
+  useOpenQuota: false,
+  quotas: [
+    {
+      key: 'new',
+      title: 'Kiintiö',
+      size: 20,
+    },
+  ],
+
+  questions: [],
+
+  verificationEmail: '',
+
+  draft: true,
+});
+
 export const resetState = () => <const>{
   type: RESET,
 };
 
-export const loaded = (event: AdminEvent.Details | null, formData: EditorEvent | null) => <const>{
+export const loaded = (event: AdminEvent.Details, formData: EditorEvent | null) => <const>{
   type: EVENT_LOADED,
   payload: {
     event,
     formData,
+    isNew: false,
+  },
+};
+
+export const newEvent = () => <const>{
+  type: EVENT_LOADED,
+  payload: {
+    event: null,
+    formData: defaultEvent(),
+    isNew: true,
   },
 };
 

--- a/src/modules/editor/reducer.ts
+++ b/src/modules/editor/reducer.ts
@@ -3,6 +3,8 @@ import {
   EVENT_LOADED,
   EVENT_SAVE_FAILED,
   EVENT_SAVING,
+  EVENT_SLUG_CHECKED,
+  EVENT_SLUG_CHECKING,
   RESET,
 } from './actionTypes';
 import { EditorActions, EditorState } from './types';
@@ -12,6 +14,7 @@ const initialState: EditorState = {
   formData: null,
   isNew: true,
   loadError: false,
+  slugAvailability: null,
   saving: false,
   saveError: false,
 };
@@ -37,6 +40,16 @@ export default function reducer(
       return {
         ...state,
         loadError: true,
+      };
+    case EVENT_SLUG_CHECKING:
+      return {
+        ...state,
+        slugAvailability: 'checking',
+      };
+    case EVENT_SLUG_CHECKED:
+      return {
+        ...state,
+        slugAvailability: action.payload,
       };
     case EVENT_SAVING:
       return {

--- a/src/modules/editor/reducer.ts
+++ b/src/modules/editor/reducer.ts
@@ -10,6 +10,7 @@ import { EditorActions, EditorState } from './types';
 const initialState: EditorState = {
   event: null,
   formData: null,
+  isNew: true,
   loadError: false,
   saving: false,
   saveError: false,
@@ -27,6 +28,7 @@ export default function reducer(
         ...state,
         event: action.payload.event,
         formData: action.payload.formData,
+        isNew: action.payload.isNew,
         loadError: false,
         saving: false,
         saveError: false,

--- a/src/modules/editor/types.d.ts
+++ b/src/modules/editor/types.d.ts
@@ -5,6 +5,7 @@ import { Question, Quota } from '../../api/events';
 import {
   loaded,
   loadFailed,
+  newEvent,
   resetState,
   saveFailed,
   saving,
@@ -13,6 +14,7 @@ import {
 interface EditorState {
   event: AdminEvent.Details | null;
   formData: EditorEvent | null;
+  isNew: boolean;
   loadError: boolean;
   saving: boolean;
   saveError: boolean;
@@ -21,6 +23,7 @@ interface EditorState {
 type EditorActions =
   | ReturnType<typeof resetState>
   | ReturnType<typeof loaded>
+  | ReturnType<typeof newEvent>
   | ReturnType<typeof loadFailed>
   | ReturnType<typeof saving>
   | ReturnType<typeof saveFailed>;

--- a/src/modules/editor/types.d.ts
+++ b/src/modules/editor/types.d.ts
@@ -1,14 +1,16 @@
 import { Moment } from 'moment';
 
-import { AdminEvent } from '../../api/adminEvents';
+import { AdminEvent, AdminSlug } from '../../api/adminEvents';
 import { Question, Quota } from '../../api/events';
 import {
+  checkingSlugAvailability,
   loaded,
   loadFailed,
   newEvent,
   resetState,
   saveFailed,
   saving,
+  slugAvailabilityChecked,
 } from './actions';
 
 interface EditorState {
@@ -16,6 +18,7 @@ interface EditorState {
   formData: EditorEvent | null;
   isNew: boolean;
   loadError: boolean;
+  slugAvailability: null | 'checking' | AdminSlug.Check;
   saving: boolean;
   saveError: boolean;
 }
@@ -25,6 +28,8 @@ type EditorActions =
   | ReturnType<typeof loaded>
   | ReturnType<typeof newEvent>
   | ReturnType<typeof loadFailed>
+  | ReturnType<typeof checkingSlugAvailability>
+  | ReturnType<typeof slugAvailabilityChecked>
   | ReturnType<typeof saving>
   | ReturnType<typeof saveFailed>;
 

--- a/src/modules/singleEvent/actions.ts
+++ b/src/modules/singleEvent/actions.ts
@@ -47,11 +47,11 @@ export const signupCancelled = () => <const>{
   type: SIGNUP_CANCELLED,
 };
 
-export const getEvent = (eventId: Event.Id | string) => async (
+export const getEvent = (slug: Event.Slug | string) => async (
   dispatch: DispatchAction,
 ) => {
   try {
-    const response = await apiFetch(`events/${eventId}`) as Event.Details;
+    const response = await apiFetch(`events/${slug}`) as Event.Details;
     dispatch(eventLoaded(response));
   } catch (e) {
     dispatch(eventLoadFailed());

--- a/src/routes/Editor/EditorToolbar.tsx
+++ b/src/routes/Editor/EditorToolbar.tsx
@@ -2,22 +2,25 @@ import React from 'react';
 
 import { useFormikContext } from 'formik';
 import { Button, ButtonGroup, Spinner } from 'react-bootstrap';
+import { shallowEqual } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { EditorEvent } from '../../modules/editor/types';
+import { useTypedSelector } from '../../store/reducers';
 
 import './Editor.scss';
 
 interface EditorToolbarProps {
-  isNew: boolean;
-  isDraft: boolean;
   onSubmitClick: (asDraft: boolean) => void;
 }
 
 type Props = EditorToolbarProps & RouteComponentProps<{ id: string }>;
 
-const EditorToolbar = ({ isNew, isDraft, onSubmitClick }: Props) => {
+const EditorToolbar = ({ onSubmitClick }: Props) => {
   const { isSubmitting } = useFormikContext<EditorEvent>();
+  const { event, isNew } = useTypedSelector((state) => state.editor, shallowEqual);
+
+  const isDraft = event?.draft || isNew;
 
   return (
     <>

--- a/src/routes/Editor/components/BasicDetailsTab.tsx
+++ b/src/routes/Editor/components/BasicDetailsTab.tsx
@@ -1,56 +1,85 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-import { Field } from 'formik';
+import { Field, useFormikContext } from 'formik';
 import { Col, Form, Row } from 'react-bootstrap';
 
 import FieldRow from '../../../components/FieldRow';
+import { EditorEvent } from '../../../modules/editor/types';
+import { useTypedSelector } from '../../../store/reducers';
 import DateTimePicker from './DateTimePicker';
+import SlugField from './SlugField';
 import Textarea from './Textarea';
 
-const BasicDetailsTab = () => (
-  <div>
-    <FieldRow
-      name="title"
-      label="Tapahtuman nimi"
-      required
-      alternateError="* Otsikko vaaditaan."
-    />
-    <FieldRow
-      name="date"
-      label="Ajankohta"
-      as={DateTimePicker}
-      required
-      alternateError="* Ajankohta vaaditaan."
-    />
-    <FieldRow
-      name="webpageUrl"
-      label="Kotisivujen osoite"
-    />
-    <FieldRow
-      name="facebookUrl"
-      label="Facebook-tapahtuma"
-    />
-    <FieldRow
-      name="location"
-      label="Paikka"
-    />
-    <FieldRow
-      name="description"
-      label="Kuvaus"
-      as={Textarea}
-    />
-    <Form.Group as={Row}>
-      <Col sm="3" />
-      <Col sm="9">
-        <Field
-          as={Form.Check}
-          name="signupsPublic"
-          id="signupsPublic"
-          label="Ilmoittautumiset ovat julkisia"
-        />
-      </Col>
-    </Form.Group>
-  </div>
-);
+const BasicDetailsTab = () => {
+  const {
+    values: { title },
+    touched: { slug: slugTouched },
+    setFieldValue,
+  } = useFormikContext<EditorEvent>();
+  const isNew = useTypedSelector((state) => state.editor.isNew);
+
+  useEffect(() => {
+    if (isNew && !slugTouched) {
+      const generatedSlug = title
+        .normalize('NFD') // converts e.g. ä to a + umlaut
+        .replace(/[^A-Za-z0-9]+/g, '')
+        .toLocaleLowerCase('fi');
+      setFieldValue('slug', generatedSlug);
+    }
+  }, [setFieldValue, isNew, title, slugTouched]);
+
+  return (
+    <div>
+      <FieldRow
+        name="title"
+        label="Tapahtuman nimi"
+        required
+        alternateError="* Otsikko vaaditaan."
+      />
+      <FieldRow
+        name="slug"
+        label="Tapahtuman URL"
+        required
+        alternateError="* URL-pääte vaaditaan."
+        as={SlugField}
+      />
+      <FieldRow
+        name="date"
+        label="Ajankohta"
+        as={DateTimePicker}
+        required
+        alternateError="* Ajankohta vaaditaan."
+      />
+      <FieldRow
+        name="webpageUrl"
+        label="Kotisivujen osoite"
+      />
+      <FieldRow
+        name="facebookUrl"
+        label="Facebook-tapahtuma"
+      />
+      <FieldRow
+        name="location"
+        label="Paikka"
+      />
+      <FieldRow
+        name="description"
+        label="Kuvaus"
+        as={Textarea}
+      />
+      <Form.Group as={Row}>
+        <Col sm="3" />
+        <Col sm="9">
+          <Field
+            as={Form.Check}
+            name="signupsPublic"
+            id="signupsPublic"
+            label="Ilmoittautumiset ovat julkisia"
+          />
+        </Col>
+      </Form.Group>
+    </div>
+  );
+};
 
 export default BasicDetailsTab;

--- a/src/routes/Editor/components/SlugField.tsx
+++ b/src/routes/Editor/components/SlugField.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Form, InputGroup } from 'react-bootstrap';
+
+export default (props: any) => {
+  const domain = /^https?:\/\//.test(PREFIX_URL) ? PREFIX_URL.replace(/^https?:\/\//, '') : window.location.host;
+  const prefix = `${domain}/event/`;
+  return (
+    <InputGroup>
+      <InputGroup.Prepend>
+        <InputGroup.Text>{prefix}</InputGroup.Text>
+      </InputGroup.Prepend>
+      <Form.Control {...props} />
+    </InputGroup>
+  );
+};

--- a/src/routes/Editor/index.tsx
+++ b/src/routes/Editor/index.tsx
@@ -7,7 +7,7 @@ import { Link, RouteComponentProps } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 import {
-  getEvent, loaded, publishEventUpdate, publishNewEvent, resetState,
+  getEvent, newEvent, publishEventUpdate, publishNewEvent, resetState,
 } from '../../modules/editor/actions';
 import { EditorEvent } from '../../modules/editor/types';
 import { useTypedDispatch, useTypedSelector } from '../../store/reducers';
@@ -29,61 +29,29 @@ interface EditSignupProps {}
 
 type Props = EditSignupProps & RouteComponentProps<MatchParams>;
 
-const defaultEvent = (): EditorEvent => ({
-  title: '',
-  slug: '',
-  date: undefined,
-  webpageUrl: '',
-  facebookUrl: '',
-  location: '',
-  description: '',
-  price: '',
-  signupsPublic: false,
-
-  registrationStartDate: undefined,
-  registrationEndDate: undefined,
-
-  openQuotaSize: 0,
-  useOpenQuota: false,
-  quotas: [
-    {
-      key: 'new',
-      title: 'Kiintiö',
-      size: 20,
-    },
-  ],
-
-  questions: [],
-
-  verificationEmail: '',
-
-  draft: true,
-});
-
 const Editor = ({ history, match }: Props) => {
   const dispatch = useTypedDispatch();
   const {
-    event, formData, loadError,
+    event, formData, isNew, loadError,
   } = useTypedSelector(
     (state) => state.editor,
     shallowEqual,
   );
 
   const eventId = match.params.id;
-  const isNew = eventId === 'new';
 
   const [activeTab, setActiveTab] = useState<EditorTabId>(1);
 
   useEffect(() => {
-    if (!isNew) {
-      dispatch(getEvent(eventId));
+    if (eventId === 'new') {
+      dispatch(newEvent());
     } else {
-      dispatch(loaded(null, defaultEvent()));
+      dispatch(getEvent(eventId));
     }
     return () => {
       dispatch(resetState());
     };
-  }, [dispatch, eventId, isNew]);
+  }, [dispatch, eventId]);
 
   // Ugly hack, but Formik doesn't really give us a clean way to
   // call setFieldValue("draft", ...) and then submit once that has propagated.
@@ -91,7 +59,7 @@ const Editor = ({ history, match }: Props) => {
 
   async function onSubmit(data: EditorEvent, { setSubmitting }: FormikHelpers<EditorEvent>) {
     // Set draft state from last submit button pressed if any, otherwise keep it as-is.
-    const draft = isNew || (saveAsDraft.current ?? event?.draft ?? true);
+    const draft = saveAsDraft.current ?? (event?.draft || isNew);
     const modifiedEvent = {
       ...data,
       quota: data.quotas,
@@ -100,8 +68,8 @@ const Editor = ({ history, match }: Props) => {
 
     try {
       if (isNew) {
-        const newEvent = await dispatch(publishNewEvent(modifiedEvent));
-        history.push(`${PREFIX_URL}/admin/edit/${newEvent.id}`);
+        const created = await dispatch(publishNewEvent(modifiedEvent));
+        history.push(`${PREFIX_URL}/admin/edit/${created.id}`);
         toast.success('Tapahtuma luotiin onnistuneesti!', {
           autoClose: 2000,
         });
@@ -156,7 +124,7 @@ const Editor = ({ history, match }: Props) => {
 
           return (
             <Form onSubmit={handleSubmit}>
-              <EditorToolbar isNew={isNew} isDraft={event!.draft} onSubmitClick={onSubmitClick} />
+              <EditorToolbar onSubmitClick={onSubmitClick} />
               <EditorTabs activeTab={activeTab} setActiveTab={setActiveTab} />
 
               <div className="event-editor--valid-notice collapsed">

--- a/src/routes/Editor/index.tsx
+++ b/src/routes/Editor/index.tsx
@@ -31,6 +31,7 @@ type Props = EditSignupProps & RouteComponentProps<MatchParams>;
 
 const defaultEvent = (): EditorEvent => ({
   title: '',
+  slug: '',
   date: undefined,
   webpageUrl: '',
   facebookUrl: '',

--- a/src/routes/Events/index.tsx
+++ b/src/routes/Events/index.tsx
@@ -50,14 +50,14 @@ const EventList = () => {
     const rows = [
       <TableRow
         className={eventState.class}
-        title={<Link to={`${PREFIX_URL}/event/${event.id}`}>{event.title}</Link>}
+        title={<Link to={`${PREFIX_URL}/event/${event.slug}`}>{event.title}</Link>}
         date={moment(event.date).format('DD.MM.YYYY')}
         signupStatus={eventState.label}
         signupCount={
           (event.quota.length < 2 ? _.sumBy(event.quota, 'signupCount') : undefined)
         }
         quotaSize={event.quota.length === 1 ? event.quota[0].size : undefined}
-        key={event.id}
+        key={event.slug}
       />,
     ];
 
@@ -68,7 +68,7 @@ const EventList = () => {
           title={quota.title}
           signupCount={quota.size ? Math.min(quota.signupCount, quota.size) : quota.signupCount}
           quotaSize={quota.size}
-          key={`${event.id}-${quota.id}`}
+          key={`${event.slug}-${quota.id}`}
         />,
       ));
     }
@@ -83,7 +83,7 @@ const EventList = () => {
             event.openQuotaSize,
           )}
           quotaSize={event.openQuotaSize}
-          key={`${event.id}-open`}
+          key={`${event.slug}-open`}
         />,
       );
     }

--- a/src/routes/SingleEvent/components/EnrollForm/index.tsx
+++ b/src/routes/SingleEvent/components/EnrollForm/index.tsx
@@ -37,7 +37,7 @@ const EnrollForm = ({ closeForm }: Props) => {
         type: toast.TYPE.SUCCESS,
         autoClose: 5000,
       });
-      dispatch(getEvent(event!.id));
+      dispatch(getEvent(event!.slug));
       closeForm();
     } else {
       toast.update(progressToast, {
@@ -57,7 +57,7 @@ const EnrollForm = ({ closeForm }: Props) => {
     if (!close) return;
 
     dispatch(cancelPendingSignup(signup!.id, signup!.editToken));
-    dispatch(getEvent(event!.id));
+    dispatch(getEvent(event!.slug));
     closeForm();
   }
 

--- a/src/routes/SingleEvent/index.tsx
+++ b/src/routes/SingleEvent/index.tsx
@@ -19,7 +19,7 @@ import SignupList from './components/SignupList';
 import './SingleEvent.scss';
 
 interface MatchParams {
-  id: string;
+  slug: string;
 }
 
 type Props = RouteComponentProps<MatchParams>;
@@ -33,11 +33,11 @@ const SingleEvent = ({ match }: Props) => {
   const [formOpen, setFormOpen] = useState(false);
 
   useEffect(() => {
-    dispatch(getEvent(match.params.id));
+    dispatch(getEvent(match.params.slug));
     return () => {
       dispatch(resetState());
     };
-  }, [dispatch, match.params.id]);
+  }, [dispatch, match.params.slug]);
 
   if (eventLoadError) {
     return (
@@ -79,7 +79,7 @@ const SingleEvent = ({ match }: Props) => {
     return (
       <EnrollForm
         closeForm={() => setFormOpen(false)}
-        key={event.id}
+        key={event.slug}
       />
     );
   }


### PR DESCRIPTION
Closes #8.

This PR adds an URL slug field to events and changes the user-visible URLs and APIs to use them. The admin side will still use event IDs, so that slugs can safely be edited in the event editor.