### PR TITLE
Actually remove deleted items from the database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,17 @@ DB_USER=ilmomasiina
 DB_PASSWORD=secret
 DB_DATABASE=ilmomasiina
 
+
+# Privacy-related settings
+
+# How long after an event's date to remove signup details.
+ANONYMIZE_AFTER_DAYS=180
+
+# How long items stay in the database after deletion, in order to allow restoring
+# accidentally deleted items.
+DELETION_GRACE_PERIOD_DAYS=14
+
+
 # Whether or not new admin accounts can be added.
 # REMEMBER TO DISABLE AFTER SETUP.
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -8,6 +8,7 @@ import cron from 'node-cron';
 import config from './config';
 import anonymizeOldSignups from './cron/anonymizeOldSignups';
 import deleteUnconfirmedSignups from './cron/deleteUnconfirmedSignups';
+import removeDeletedData from './cron/removeDeletedData';
 import models from './models';
 import services from './services';
 
@@ -29,6 +30,9 @@ cron.schedule('* * * * *', deleteUnconfirmedSignups);
 
 // Daily at 8am, anonymize old signups
 cron.schedule('0 8 * * *', anonymizeOldSignups);
+
+// Daily at 8am, delete deleted items from the database
+cron.schedule('0 8 * * *', removeDeletedData);
 
 // Serve compiled frontend (TODO: implement Webpack dev server)
 app.use(express.static('../../dist'));

--- a/server/config.ts
+++ b/server/config.ts
@@ -33,6 +33,7 @@ const config = {
   adminRegistrationAllowed: process.env.ADMIN_REGISTRATION_ALLOWED === 'true',
 
   anonymizeAfterDays: process.env.ANONYMIZE_AFTER_DAYS || 180,
+  deletionGracePeriod: process.env.DELETION_GRACE_PERIOD_DAYS || 14,
 };
 
 Object.entries(config).forEach(([key, value]) => {

--- a/server/cron/deleteUnconfirmedSignups.ts
+++ b/server/cron/deleteUnconfirmedSignups.ts
@@ -17,6 +17,8 @@ export default async function deleteUnconfirmedSignups() {
         },
       },
     },
+    // Also already-deleted signups
+    paranoid: false,
   });
 
   if (signups.length === 0) {
@@ -30,7 +32,11 @@ export default async function deleteUnconfirmedSignups() {
   console.log(ids);
   try {
     // TODO: send emails to signups accepted from queue
-    await Signup.unscoped().destroy({ where: { id: ids } });
+    await Signup.unscoped().destroy({
+      where: { id: ids },
+      // skip deletion grace period
+      force: true,
+    });
     console.log('Unconfirmed signups deleted');
   } catch (error) {
     console.error(error);

--- a/server/cron/removeDeletedData.ts
+++ b/server/cron/removeDeletedData.ts
@@ -1,0 +1,62 @@
+import moment from 'moment';
+import { Op, WhereOptions } from 'sequelize';
+
+import config from '../config';
+import { Answer } from '../models/answer';
+import { Event } from '../models/event';
+import { Question } from '../models/question';
+import { Quota } from '../models/quota';
+import { Signup } from '../models/signup';
+
+export default async function removeDeletedData() {
+  const ifRemovedBefore = moment().subtract(config.deletionGracePeriod, 'days').toDate();
+
+  await Event.unscoped().destroy({
+    where: {
+      deletedAt: {
+        [Op.lt]: ifRemovedBefore,
+      },
+    // Manually adding and initializing deletedAt in _every_ model would be counter-productive,
+    // so casting to avoid a type error here.
+    } as WhereOptions,
+    force: true,
+  });
+
+  await Question.unscoped().destroy({
+    where: {
+      deletedAt: {
+        [Op.lt]: ifRemovedBefore,
+      },
+    } as WhereOptions,
+    force: true,
+  });
+
+  await Quota.unscoped().destroy({
+    where: {
+      deletedAt: {
+        [Op.lt]: ifRemovedBefore,
+      },
+    } as WhereOptions,
+    force: true,
+  });
+
+  await Signup.unscoped().destroy({
+    where: {
+      deletedAt: {
+        [Op.lt]: ifRemovedBefore,
+      },
+    } as WhereOptions,
+    force: true,
+  });
+
+  // Technically shouldn't be necessary due to how ON DELETE CASCADE and paranoid mode interact,
+  // but here for completeness' sake.
+  await Answer.unscoped().destroy({
+    where: {
+      deletedAt: {
+        [Op.lt]: ifRemovedBefore,
+      },
+    } as WhereOptions,
+    force: true,
+  });
+}


### PR DESCRIPTION
Closes #12.

The app uses Sequelize's paranoid mode, which doesn't really delete data from the database, only marks it as deleted. That creates privacy concerns.

This PR adds a cron job that deletes marked-deleted data from the database. There is a configurable (default 14 days) grace period after marking as deleted, so that accidental deletions can be reversed manually.