### PR TITLE
Fix naming of 'quotas' in API

### DIFF
--- a/server/services/admin/event/createEvent.ts
+++ b/server/services/admin/event/createEvent.ts
@@ -45,8 +45,7 @@ export interface AdminEventCreateQuota extends Pick<Quota, typeof adminEventCrea
 
 export interface AdminEventCreateBody extends Pick<Event, typeof adminEventCreateEventAttrs[number]> {
   questions: AdminEventCreateQuestion[];
-  // intentionally misnamed to match old API
-  quota: AdminEventCreateQuota[];
+  quotas: AdminEventCreateQuota[];
 }
 
 export default async (data: AdminEventCreateBody): Promise<AdminEventGetResponse> => {
@@ -54,7 +53,7 @@ export default async (data: AdminEventCreateBody): Promise<AdminEventGetResponse
   const attribs = {
     ..._.pick(data, adminEventCreateEventAttrs),
     questions: data.questions?.map((question) => _.pick(question, adminEventCreateQuestionAttrs)),
-    quotas: data.quota?.map((quota) => _.pick(quota, adminEventCreateQuotaAttrs)),
+    quotas: data.quotas?.map((quota) => _.pick(quota, adminEventCreateQuotaAttrs)),
   };
 
   // Create the event with relations - Sequelize will handle validation

--- a/server/services/admin/event/updateEvent.ts
+++ b/server/services/admin/event/updateEvent.ts
@@ -19,8 +19,7 @@ export interface AdminEventUpdateQuota extends Pick<Quota, typeof adminEventCrea
 
 export interface AdminEventUpdateBody extends Pick<Event, typeof adminEventCreateEventAttrs[number]> {
   questions: AdminEventUpdateQuestion[];
-  // intentionally misnamed to match old API
-  quota: AdminEventUpdateQuota[];
+  quotas: AdminEventUpdateQuota[];
 }
 
 export default async (id: number, data: Partial<AdminEventUpdateBody>): Promise<AdminEventGetResponse> => {
@@ -74,7 +73,7 @@ export default async (id: number, data: Partial<AdminEventUpdateBody>): Promise<
         attributes: ['id'],
         transaction,
       });
-      const newIds = _.filter(_.map(data.questions, 'id')) as number[];
+      const newIds = _.filter(_.map(data.questions, 'id')) as Question['id'][];
       await Question.destroy({
         where: {
           eventId: event.id,
@@ -100,14 +99,14 @@ export default async (id: number, data: Partial<AdminEventUpdateBody>): Promise<
       }));
     }
 
-    if (data.quota !== undefined) {
+    if (data.quotas !== undefined) {
       // Remove previous Quotas not present in request
       // (TODO: require confirmation if there are signups)
       const oldQuotas = await event.getQuotas({
         attributes: ['id'],
         transaction,
       });
-      const newIds = _.filter(_.map(data.quota, 'id')) as number[];
+      const newIds = _.filter(_.map(data.quotas, 'id')) as Quota['id'][];
       await Quota.destroy({
         where: {
           eventId: event.id,
@@ -118,7 +117,7 @@ export default async (id: number, data: Partial<AdminEventUpdateBody>): Promise<
         transaction,
       });
       // Update the Quotas
-      await Promise.all(data.quota.map(async (quota) => {
+      await Promise.all(data.quotas.map(async (quota) => {
         const quotaAttribs = _.pick(quota, adminEventCreateQuotaAttrs);
         // See if the quota already exists
         const existing = quota.id && _.find(oldQuotas, { id: quota.id });

--- a/server/services/event/getEventDetails.ts
+++ b/server/services/event/getEventDetails.ts
@@ -88,8 +88,7 @@ export interface EventGetQuotaItem extends Pick<Quota, typeof eventGetQuotaAttrs
 
 export interface EventGetResponse extends Pick<Event, typeof eventGetEventAttrs[number]> {
   questions: EventGetQuestionItem[];
-  // intentionally misnamed to match old API
-  quota: EventGetQuotaItem[];
+  quotas: EventGetQuotaItem[];
   millisTillOpening?: number;
   registrationClosed?: boolean;
 }
@@ -111,8 +110,7 @@ export interface AdminEventGetQuotaItem extends Pick<Quota, typeof eventGetQuota
 
 export interface AdminEventGetResponse extends Pick<Event, typeof adminEventGetEventAttrs[number]> {
   questions: AdminEventGetQuestionItem[];
-  // intentionally misnamed to match old API
-  quota: AdminEventGetQuotaItem[];
+  quotas: AdminEventGetQuotaItem[];
   millisTillOpening?: number;
   registrationClosed?: boolean;
 }
@@ -183,7 +181,7 @@ async function getEventDetails<A extends boolean>(
       options: question.options ? question.options.split(';') : null,
     })),
 
-    quota: event.quotas!.map((quota) => {
+    quotas: event.quotas!.map((quota) => {
       // Hide all signups from non-admins if answers are not public
       let signups = null;
 

--- a/server/services/event/getEventsList.ts
+++ b/server/services/event/getEventsList.ts
@@ -36,8 +36,7 @@ export interface EventListQuotaItem extends Pick<Quota, typeof eventListQuotaAtt
 }
 
 export interface EventListItem extends Pick<Event, typeof eventListEventAttrs[number]> {
-  // intentionally misnamed to match old API
-  quota: EventListQuotaItem[];
+  quotas: EventListQuotaItem[];
 }
 
 export type EventListResponse = EventListItem[];
@@ -47,8 +46,7 @@ export type EventListResponse = EventListItem[];
 export type AdminEventListQuotaItem = EventListQuotaItem;
 
 export interface AdminEventListItem extends Pick<Event, typeof adminEventListEventAttrs[number]> {
-  // intentionally misnamed to match old API
-  quota: AdminEventListQuotaItem[];
+  quotas: AdminEventListQuotaItem[];
 }
 
 export type AdminEventListResponse = AdminEventListItem[];
@@ -88,7 +86,7 @@ async function getEventsList<A extends boolean>(admin: A): Promise<EventListResp
   // Convert event list to response
   const result: EventListResponseType<A> = events.map((event) => ({
     ..._.pick(event, eventAttrs),
-    quota: event.quotas!.map((quota) => ({
+    quotas: event.quotas!.map((quota) => ({
       ..._.pick(quota, eventListQuotaAttrs),
       signupCount: quota.signupCount!,
     })),

--- a/src/modules/editor/actions.ts
+++ b/src/modules/editor/actions.ts
@@ -96,7 +96,7 @@ const serverEventToEditor = (event: AdminEvent.Details): EditorEvent => ({
   date: moment(event.date),
   registrationStartDate: moment(event.registrationStartDate),
   registrationEndDate: moment(event.registrationEndDate),
-  quotas: event.quota.map((quota) => ({
+  quotas: event.quotas.map((quota) => ({
     ...quota,
     key: quota.id,
   })),
@@ -113,7 +113,7 @@ const editorEventToServer = (form: EditorEvent): AdminEvent.Update.Body => ({
   date: form.date?.toISOString() || '',
   registrationStartDate: form.registrationStartDate?.toISOString() || '',
   registrationEndDate: form.registrationEndDate?.toISOString() || '',
-  quota: form.quotas,
+  quotas: form.quotas,
   openQuotaSize: form.useOpenQuota ? form.openQuotaSize : 0,
   questions: form.questions.map((question) => ({
     ...question,

--- a/src/routes/Admin/AdminEventListItem.tsx
+++ b/src/routes/Admin/AdminEventListItem.tsx
@@ -38,7 +38,7 @@ const AdminEventListItem = ({ event }: Props) => {
       </td>
       <td>{event.date ? moment(event.date).format('DD.MM.YYYY') : ''}</td>
       <td>{event.draft ? 'Luonnos' : 'Julkaistu'}</td>
-      <td>{_.sum(_.map(event.quota, 'signupCount'))}</td>
+      <td>{_.sum(_.map(event.quotas, 'signupCount'))}</td>
       <td>
         <Link to={`${PREFIX_URL}/admin/edit/${event.id}`}>
           Muokkaa tapahtumaa

--- a/src/routes/Events/index.tsx
+++ b/src/routes/Events/index.tsx
@@ -45,45 +45,48 @@ const EventList = () => {
   const eventsSorted = _.sortBy(events, ['date', 'title']);
 
   const tableRows = eventsSorted.flatMap((event) => {
-    const eventState = signupState(event.date, event.registrationStartDate, event.registrationEndDate);
+    const {
+      slug, title, date, registrationStartDate, registrationEndDate, quotas, openQuotaSize,
+    } = event;
+    const eventState = signupState(date, registrationStartDate, registrationEndDate);
 
     const rows = [
       <TableRow
         className={eventState.class}
-        title={<Link to={`${PREFIX_URL}/event/${event.slug}`}>{event.title}</Link>}
-        date={moment(event.date).format('DD.MM.YYYY')}
+        title={<Link to={`${PREFIX_URL}/event/${slug}`}>{title}</Link>}
+        date={moment(date).format('DD.MM.YYYY')}
         signupStatus={eventState.label}
         signupCount={
-          (event.quota.length < 2 ? _.sumBy(event.quota, 'signupCount') : undefined)
+          (quotas.length < 2 ? _.sumBy(quotas, 'signupCount') : undefined)
         }
-        quotaSize={event.quota.length === 1 ? event.quota[0].size : undefined}
-        key={event.slug}
+        quotaSize={quotas.length === 1 ? quotas[0].size : undefined}
+        key={slug}
       />,
     ];
 
-    if (event.quota.length > 1) {
-      event.quota.map((quota) => rows.push(
+    if (quotas.length > 1) {
+      quotas.map((quota) => rows.push(
         <TableRow
           className="child"
           title={quota.title}
           signupCount={quota.size ? Math.min(quota.signupCount, quota.size) : quota.signupCount}
           quotaSize={quota.size}
-          key={`${event.slug}-${quota.id}`}
+          key={`${slug}-${quota.id}`}
         />,
       ));
     }
 
-    if (event.openQuotaSize > 0) {
+    if (openQuotaSize > 0) {
       rows.push(
         <TableRow
           className="child"
           title="Avoin"
           signupCount={Math.min(
-            _.sum(event.quota.map((quota) => (quota.size ? Math.max(0, quota.signupCount - quota.size) : 0))),
-            event.openQuotaSize,
+            _.sum(quotas.map((quota) => (quota.size ? Math.max(0, quota.signupCount - quota.size) : 0))),
+            openQuotaSize,
           )}
-          quotaSize={event.openQuotaSize}
-          key={`${event.slug}-open`}
+          quotaSize={openQuotaSize}
+          key={`${slug}-open`}
         />,
       );
     }

--- a/src/routes/SingleEvent/components/EnrollForm/SignupStatus.tsx
+++ b/src/routes/SingleEvent/components/EnrollForm/SignupStatus.tsx
@@ -6,7 +6,7 @@ import { useTypedSelector } from '../../../../store/reducers';
 
 const SignupStatus = () => {
   const { status, position, quotaId } = useTypedSelector((state) => state.singleEvent.signup)!;
-  const { quota: quotas, openQuotaSize } = useTypedSelector((state) => state.singleEvent.event)!;
+  const { quotas, openQuotaSize } = useTypedSelector((state) => state.singleEvent.event)!;
 
   if (!status) return null;
 

--- a/src/routes/SingleEvent/components/SignupCountdown/SignupButton.tsx
+++ b/src/routes/SingleEvent/components/SignupCountdown/SignupButton.tsx
@@ -21,28 +21,24 @@ const SignupButton = (props: SignupButtonProps) => {
     isOpen, beginSignup, seconds, total,
   } = props;
 
-  const event = useTypedSelector((state) => state.singleEvent.event)!;
+  const {
+    date, registrationStartDate, registrationEndDate, quotas,
+  } = useTypedSelector((state) => state.singleEvent.event)!;
   const submitting = useTypedSelector((state) => state.singleEvent.signupSubmitting);
-  const isOnly = event.quota.length === 1;
+  const isOnly = quotas.length === 1;
 
   return (
     <div className="sidebar-widget">
       <h3>Ilmoittautuminen</h3>
       <p>
-        {
-          signupState(
-            event.date,
-            event.registrationStartDate,
-            event.registrationEndDate,
-          ).label
-        }
+        {signupState(date, registrationStartDate, registrationEndDate).label}
         {total < COUNTDOWN_DURATION && !isOpen ? (
           <span style={{ color: 'green' }}>
             {` (${seconds}  s)`}
           </span>
         ) : null}
       </p>
-      {event.quota.map((quota) => (
+      {quotas.map((quota) => (
         <Button
           key={quota.id}
           type="button"

--- a/src/utils/signupUtils.ts
+++ b/src/utils/signupUtils.ts
@@ -30,7 +30,7 @@ export function getSignupsByQuota(event: AnyEventDetails) {
   let overflow: SignupWithQuotaName[] = [];
   const quotas: QuotaSignups[] = [];
 
-  event.quota.forEach((quota) => {
+  event.quotas.forEach((quota) => {
     if (!quota.signups) return;
 
     const sorted = _.sortBy(quota.signups, 'createdAt').map((signup) => ({


### PR DESCRIPTION
The TypeScript port left the API exactly compatible with the original frontend. This included a misnamed member that was inherited from the column name auto-generated using `node-inflection`: `quota` that contained multiple quotas. (Maybe `quota` would be grammatically correct, but `quotas` is the plural used in this application.)

This PR removes that artifact and cleans up some code near its uses using destructuring.