### PR TITLE
Move signup state to server side

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -51,7 +51,8 @@ Each Question has one **Event** and zero or more **Answers**.
 
 ### Signup
 
-**Signup** instances are assigned to a **Quota**. Signup instances only hold their basic fields (name/email).
+**Signup** instances are assigned to a **Quota**. Signup instances hold their basic fields (name/email) and their
+cached quota assignment.
 
 Signups can be enumerated and deleted per-event by admins, and in a limited fashion by users.
 They can also be viewed, modified and deleted using their edit token, which is computed statelessly.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -64,4 +64,10 @@ ADD `order` INTEGER NOT NULL AFTER `eventId`;
 
 ALTER TABLE `event`
 ADD `listed` BOOLEAN NOT NULL DEFAULT 1 AFTER `draft`;
+
+-- store status and position in signups
+
+ALTER TABLE `signup`
+ADD `status` ENUM('in-quota', 'in-open', 'in-queue') DEFAULT NULL AFTER `confirmedAt`,
+ADD `position` INTEGER DEFAULT NULL AFTER `status`;
 ```

--- a/server/cron/deleteUnconfirmedSignups.ts
+++ b/server/cron/deleteUnconfirmedSignups.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import moment from 'moment';
 import { Op } from 'sequelize';
 
@@ -42,11 +43,7 @@ export default async function deleteUnconfirmedSignups() {
   }
 
   const signupIds = signups.map((signup) => signup.id);
-  const uniqueEvents = new Map(
-    signups
-      .map((signup) => signup.quota!.event!)
-      .map((event) => [event.id, event]),
-  ).values();
+  const uniqueEvents = _.uniqBy(signups.map((signup) => signup.quota!.event!), 'id');
 
   console.log('Deleting unconfirmed signups:');
   console.log(signupIds);

--- a/server/models/signup.ts
+++ b/server/models/signup.ts
@@ -12,18 +12,24 @@ import { Answer } from './answer';
 import { Quota } from './quota';
 import { generateRandomId, RANDOM_ID_LENGTH } from './randomId';
 
+export const signupStatuses = ['in-quota', 'in-open', 'in-queue'] as const;
+export type SignupStatus = typeof signupStatuses[number];
+
 export interface SignupAttributes {
   id: string;
   firstName: string | null;
   lastName: string | null;
   email: string | null;
   confirmedAt: Date | null;
+  status: SignupStatus | null;
+  position: number | null;
   createdAt: Date;
   quotaId: Quota['id'];
 }
 
 export interface SignupCreationAttributes
-  extends Optional<SignupAttributes, 'id' | 'firstName' | 'lastName' | 'email' | 'confirmedAt' | 'createdAt'> {}
+  extends Optional<SignupAttributes, 'id' | 'firstName' | 'lastName' | 'email' | 'confirmedAt'
+  | 'status' | 'position' | 'createdAt'> {}
 
 export class Signup extends Model<SignupAttributes, SignupCreationAttributes> implements SignupAttributes {
   public id!: string;
@@ -31,6 +37,8 @@ export class Signup extends Model<SignupAttributes, SignupCreationAttributes> im
   public lastName!: string | null;
   public email!: string | null;
   public confirmedAt!: Date | null;
+  public status!: SignupStatus | null;
+  public position!: number | null;
 
   public quotaId!: Quota['id'];
   public quota?: Quota;
@@ -89,10 +97,17 @@ export default function setupSignupModel(this: IlmoApplication) {
       confirmedAt: {
         type: DataTypes.DATE(3),
       },
+      status: {
+        type: DataTypes.ENUM(...signupStatuses),
+      },
+      position: {
+        type: DataTypes.INTEGER,
+      },
       // Add createdAt manually to support milliseconds
       createdAt: {
         type: DataTypes.DATE(3),
         defaultValue: () => new Date(),
+        allowNull: false,
       },
     },
     {

--- a/server/services/event/getEventDetails.ts
+++ b/server/services/event/getEventDetails.ts
@@ -53,6 +53,8 @@ export const eventGetQuotaAttrs = [
 export const eventGetSignupAttrs = [
   'firstName',
   'lastName',
+  'status',
+  'position',
   'createdAt',
 ] as const;
 

--- a/server/services/signup/computeSignupPosition.ts
+++ b/server/services/signup/computeSignupPosition.ts
@@ -1,69 +1,112 @@
-import _ from 'lodash';
-import { col, fn, Op } from 'sequelize';
+import moment from 'moment';
+import { Transaction, WhereOptions } from 'sequelize';
 
+import EmailService from '../../mail';
+import { Event } from '../../models/event';
 import { Quota } from '../../models/quota';
-import { Signup } from '../../models/signup';
-import { SignupState } from './createNewSignup';
+import { Signup, SignupStatus } from '../../models/signup';
 
-export default async (signup: Signup) => {
-  const currentQuota = await signup.getQuota()!;
-
-  const event = await currentQuota.getEvent({
-    attributes: ['id', 'openQuotaSize', 'signupsPublic'],
-    // Include all quotas for the event
-    include: [{
-      model: Quota,
-      attributes: [
-        'id',
-        'size',
-        // Count all signups for each quota
-        [fn('COUNT', col('quotas->signups.id')), 'signupCount'],
-      ],
-      include: [{
-        model: Signup,
-        attributes: [],
-        where: {
-          // Only include this signup and ones older than it.
-          createdAt: {
-            // TODO: will this fail if there are signups on the same millisecond?
-            [Op.lte]: signup.createdAt,
-          },
-        },
-      }],
-    }],
-    group: [col('event.id'), col('quotas.id')],
-  });
-  const positionInQuota = _.find(event.quotas!, { id: currentQuota.id })!.signupCount!;
-
-  let position = null;
-  let status: SignupState | null = null;
-
-  if (event.signupsPublic) {
-    if (currentQuota.size === null || positionInQuota <= currentQuota.size) {
-      // Fits in the selected quota or the selected quota is unlimited.
-      position = positionInQuota;
-      status = 'in-quota';
-    } else {
-      // Count how many signups (older than this one) don't fit each quota.
-      // This is our position in the open quota.
-      const positionInOpen = _.sumBy(
-        event.quotas!,
-        (quota) => (quota.size ? Math.max(0, quota.signupCount! - quota.size) : 0),
-      );
-
-      if (positionInOpen <= event.openQuotaSize && event.openQuotaSize > 0) {
-        position = positionInOpen;
-        status = 'in-open';
-      } else {
-        const positionInQueue = Math.max(0, positionInOpen - Number(event.openQuotaSize));
-        position = positionInQueue;
-        status = 'in-queue';
-      }
-    }
-  }
-
-  return {
-    position,
-    status,
-  };
+export type SignupPositionStatus = {
+  status: SignupStatus;
+  position: number;
 };
+
+async function sendPromotedFromQueueEmail(signup: Signup, eventId: Event['id']) {
+  if (signup.email === null) return;
+
+  // Re-fetch event for all attributes
+  const event = await Event.findByPk(eventId);
+  if (event === null) throw new Error('event missing when sending queue email');
+
+  const params = {
+    event,
+    date: moment(event.date).tz('Europe/Helsinki').format('DD.MM.YYYY HH:mm'),
+  };
+  EmailService.sendPromotedFromQueueEmail(signup.email, params);
+}
+
+/**
+ * Updates the status and position attributes on all signups in the given event. Also sends "promoted from queue"
+ * emails to affected users. Returns the new statuses for all signups.
+ *
+ * Make sure that the event passed contains `id`, `openQuotaSize`.
+ */
+export function refreshSignupPositions(event: Event): Promise<Map<Signup['id'], SignupPositionStatus>> {
+  return Event.sequelize!.transaction(async (transaction) => {
+    const signups = await Signup.findAll({
+      attributes: ['id', 'quotaId', 'email', 'status', 'position'],
+      include: [
+        {
+          model: Quota,
+          attributes: ['id', 'size'],
+        },
+      ],
+      where: {
+        '$quota.eventId$': event.id,
+      } as WhereOptions,
+      // Honor creation time, tie-break by random ID in case of same millisecond
+      order: [
+        ['createdAt', 'ASC'],
+        ['id', 'ASC'],
+      ],
+      // Prevent simultaneous changes
+      lock: Transaction.LOCK.UPDATE,
+      transaction,
+    });
+
+    const quotaSignups = new Map<Quota['id'], number>();
+    let inOpenQuota = 0;
+    let inQueue = 0;
+
+    const result = await Promise.all(signups.map(async (signup: Signup) => {
+      let status: SignupStatus;
+      let position: number;
+
+      let inChosenQuota = quotaSignups.get(signup.quotaId) ?? 0;
+      const chosenQuotaSize = signup.quota!.size ?? Infinity;
+
+      // Assign the selected or open quotas if free. Never worsen a signup's status.
+      if (signup.status === 'in-quota' || inChosenQuota < chosenQuotaSize) {
+        inChosenQuota += 1;
+        quotaSignups.set(signup.quotaId, inChosenQuota);
+        status = 'in-quota';
+        position = inChosenQuota;
+      } else if (signup.status === 'in-open' || inOpenQuota < event.openQuotaSize) {
+        inOpenQuota += 1;
+        status = 'in-open';
+        position = inOpenQuota;
+      } else {
+        inQueue += 1;
+        status = 'in-queue';
+        position = inQueue;
+      }
+
+      // If the signup was just promoted from the queue, send an email about it asynchronously.
+      if (signup.status === 'in-queue' && status !== 'in-queue') {
+        sendPromotedFromQueueEmail(signup, event.id);
+      }
+
+      // Store changes in database, if any
+      if (signup.status !== status || signup.position !== position) {
+        await signup.update(
+          { status, position },
+          { transaction },
+        );
+      }
+
+      return <const>[signup.id, { status, position }];
+    }));
+
+    return new Map(result);
+  });
+}
+
+/**
+ * Like `refreshSignupPositions`, but returns the status for the given signup.
+ */
+export async function refreshSignupPositionsAndGet(event: Event, signupId: Signup['id']) {
+  const positionMap = await refreshSignupPositions(event);
+  const position = positionMap.get(signupId);
+  if (!position) throw new Error('failed to compute status');
+  return position;
+}

--- a/server/services/signup/computeSignupPosition.ts
+++ b/server/services/signup/computeSignupPosition.ts
@@ -6,11 +6,6 @@ import { Event } from '../../models/event';
 import { Quota } from '../../models/quota';
 import { Signup, SignupStatus } from '../../models/signup';
 
-export type SignupPositionStatus = {
-  status: SignupStatus;
-  position: number;
-};
-
 async function sendPromotedFromQueueEmail(signup: Signup, eventId: Event['id']) {
   if (signup.email === null) return;
 
@@ -31,82 +26,93 @@ async function sendPromotedFromQueueEmail(signup: Signup, eventId: Event['id']) 
  *
  * Make sure that the event passed contains `id`, `openQuotaSize`.
  */
-export function refreshSignupPositions(event: Event): Promise<Map<Signup['id'], SignupPositionStatus>> {
-  return Event.sequelize!.transaction(async (transaction) => {
-    const signups = await Signup.findAll({
-      attributes: ['id', 'quotaId', 'email', 'status', 'position'],
-      include: [
-        {
-          model: Quota,
-          attributes: ['id', 'size'],
-        },
-      ],
-      where: {
-        '$quota.eventId$': event.id,
-      } as WhereOptions,
-      // Honor creation time, tie-break by random ID in case of same millisecond
-      order: [
-        ['createdAt', 'ASC'],
-        ['id', 'ASC'],
-      ],
-      // Prevent simultaneous changes
-      lock: Transaction.LOCK.UPDATE,
-      transaction,
-    });
+export async function refreshSignupPositions(event: Event, transaction?: Transaction): Promise<Signup[]> {
+  // Wrap in transaction if not given
+  if (!transaction) {
+    return Event.sequelize!.transaction(
+      async (trans) => refreshSignupPositions(event, trans),
+    );
+  }
 
-    const quotaSignups = new Map<Quota['id'], number>();
-    let inOpenQuota = 0;
-    let inQueue = 0;
-
-    const result = await Promise.all(signups.map(async (signup: Signup) => {
-      let status: SignupStatus;
-      let position: number;
-
-      let inChosenQuota = quotaSignups.get(signup.quotaId) ?? 0;
-      const chosenQuotaSize = signup.quota!.size ?? Infinity;
-
-      // Assign the selected or open quotas if free. Never worsen a signup's status.
-      if (signup.status === 'in-quota' || inChosenQuota < chosenQuotaSize) {
-        inChosenQuota += 1;
-        quotaSignups.set(signup.quotaId, inChosenQuota);
-        status = 'in-quota';
-        position = inChosenQuota;
-      } else if (signup.status === 'in-open' || inOpenQuota < event.openQuotaSize) {
-        inOpenQuota += 1;
-        status = 'in-open';
-        position = inOpenQuota;
-      } else {
-        inQueue += 1;
-        status = 'in-queue';
-        position = inQueue;
-      }
-
-      // If the signup was just promoted from the queue, send an email about it asynchronously.
-      if (signup.status === 'in-queue' && status !== 'in-queue') {
-        sendPromotedFromQueueEmail(signup, event.id);
-      }
-
-      // Store changes in database, if any
-      if (signup.status !== status || signup.position !== position) {
-        await signup.update(
-          { status, position },
-          { transaction },
-        );
-      }
-
-      return <const>[signup.id, { status, position }];
-    }));
-
-    return new Map(result);
+  const signups = await Signup.findAll({
+    attributes: ['id', 'quotaId', 'email', 'status', 'position'],
+    include: [
+      {
+        model: Quota,
+        attributes: ['id', 'size'],
+      },
+    ],
+    where: {
+      '$quota.eventId$': event.id,
+    } as WhereOptions,
+    // Honor creation time, tie-break by random ID in case of same millisecond
+    order: [
+      ['createdAt', 'ASC'],
+      ['id', 'ASC'],
+    ],
+    // Prevent simultaneous changes
+    lock: Transaction.LOCK.UPDATE,
+    transaction,
   });
+
+  // Assign each signup to a quota or the queue.
+  const quotaSignups = new Map<Quota['id'], number>();
+  let inOpenQuota = 0;
+  let inQueue = 0;
+
+  const result = signups.map((signup: Signup) => {
+    let status: SignupStatus;
+    let position: number;
+
+    let inChosenQuota = quotaSignups.get(signup.quotaId) ?? 0;
+    const chosenQuotaSize = signup.quota!.size ?? Infinity;
+
+    // Assign the selected or open quotas if free. Never worsen a signup's status.
+    if (signup.status === 'in-quota' || inChosenQuota < chosenQuotaSize) {
+      inChosenQuota += 1;
+      quotaSignups.set(signup.quotaId, inChosenQuota);
+      status = 'in-quota';
+      position = inChosenQuota;
+    } else if (signup.status === 'in-open' || inOpenQuota < event.openQuotaSize) {
+      inOpenQuota += 1;
+      status = 'in-open';
+      position = inOpenQuota;
+    } else {
+      inQueue += 1;
+      status = 'in-queue';
+      position = inQueue;
+    }
+
+    return { signup, status, position };
+  });
+
+  // If a signup was just promoted from the queue, send an email about it asynchronously.
+  result.forEach(({ signup, status }) => {
+    if (signup.status === 'in-queue' && status !== 'in-queue') {
+      sendPromotedFromQueueEmail(signup, event.id);
+    }
+  });
+
+  // Store changes in database, if any.
+  await Promise.all(result.map(async ({ signup, status, position }) => {
+    if (signup.status !== status || signup.position !== position) {
+      await signup.update(
+        { status, position },
+        { transaction },
+      );
+    }
+  }));
+
+  return result.map(({ signup }) => signup);
 }
 
 /**
  * Like `refreshSignupPositions`, but returns the status for the given signup.
  */
 export async function refreshSignupPositionsAndGet(event: Event, signupId: Signup['id']) {
-  const positionMap = await refreshSignupPositions(event);
-  const position = positionMap.get(signupId);
-  if (!position) throw new Error('failed to compute status');
-  return position;
+  const result = await refreshSignupPositions(event);
+  const signup = result.find(({ id }) => id === signupId);
+  if (!signup) throw new Error('failed to compute status');
+  const { status, position } = signup;
+  return { status, position };
 }

--- a/server/services/signup/deleteSignup.ts
+++ b/server/services/signup/deleteSignup.ts
@@ -1,50 +1,13 @@
 import { NotFound } from '@feathersjs/errors';
 import { Params } from '@feathersjs/feathers';
-import moment from 'moment';
 
-import EmailService from '../../mail';
 import { Event } from '../../models/event';
+import { Quota } from '../../models/quota';
 import { Signup } from '../../models/signup';
+import { refreshSignupPositions } from './computeSignupPosition';
 import { verifyToken } from './editTokens';
 
 type AdminParams = { adminAuthenticated: true };
-
-async function advanceQueueAfterDeletion(deletedSignup: Signup) {
-  const currentQuota = await deletedSignup.getQuota({
-    include: [
-      {
-        model: Event,
-      },
-    ],
-  })!;
-  const event = currentQuota.event!;
-
-  // No need to check if the quota is infinite
-  if (!currentQuota.size) return;
-
-  // TODO: fix this, currently doesn't handle open quota correctly
-  const { count, rows } = await Signup.findAndCountAll({
-    where: { quotaId: currentQuota.id } /* TODO */ as any,
-    // Only retrieve the entry that just got accepted from the queue
-    limit: 1,
-    offset: currentQuota.size + event.openQuotaSize - 1,
-  });
-  if (count >= currentQuota.size) {
-    // There is someone that just got accepted from the queue, inform them
-    const promotedFromQueue = rows[0];
-
-    // No need to send email now if they have yet to confirm their signup
-    if (promotedFromQueue.confirmedAt === null) {
-      return;
-    }
-
-    const params = {
-      event,
-      date: moment(event.date).tz('Europe/Helsinki').format('DD.MM.YYYY HH:mm'),
-    };
-    EmailService.sendPromotedFromQueueEmail(promotedFromQueue.email!, params);
-  }
-}
 
 export default async (id: string, params?: Params | AdminParams): Promise<null> => {
   if (!params?.adminAuthenticated) {
@@ -52,16 +15,29 @@ export default async (id: string, params?: Params | AdminParams): Promise<null> 
     verifyToken(id, editToken);
   }
 
-  const signup = await Signup.findByPk(id);
+  const signup = await Signup.findByPk(id, {
+    include: [
+      {
+        model: Quota,
+        attributes: [],
+        include: [
+          {
+            model: Event,
+            attributes: ['id', 'registrationStartDate', 'registrationEndDate', 'openQuotaSize'],
+          },
+        ],
+      },
+    ],
+  });
   if (signup === null) {
     throw new NotFound('No signup found with id');
   }
 
   // Delete the DB object
-  await signup?.destroy();
+  await signup.destroy();
 
   // Advance the queue and send emails to people that were accepted
-  await advanceQueueAfterDeletion(signup);
+  await refreshSignupPositions(signup.quota!.event!);
 
   return null;
 };

--- a/server/services/signup/getSignupForEdit.ts
+++ b/server/services/signup/getSignupForEdit.ts
@@ -27,6 +27,8 @@ const signupGetSignupAttrs = [
   'firstName',
   'lastName',
   'email',
+  'status',
+  'position',
 ] as const;
 
 // Data type definitions for this endpoint - pick columns and add included relations

--- a/src/routes/SingleEvent/components/SignupList/TableRow.tsx
+++ b/src/routes/SingleEvent/components/SignupList/TableRow.tsx
@@ -4,12 +4,12 @@ import _ from 'lodash';
 import moment from 'moment-timezone';
 
 import { useTypedSelector } from '../../../../store/reducers';
-import { SignupWithQuotaName } from '../../../../utils/signupUtils';
+import { SignupWithQuota } from '../../../../utils/signupUtils';
 
 type Props = {
   index: number;
   showQuota: boolean;
-  signup: SignupWithQuotaName;
+  signup: SignupWithQuota;
 };
 
 const TableRow = ({ showQuota, signup, index }: Props) => {

--- a/src/routes/SingleEvent/components/SignupList/index.tsx
+++ b/src/routes/SingleEvent/components/SignupList/index.tsx
@@ -12,24 +12,13 @@ type Props = {
   quota: QuotaSignups;
 };
 
-function getTitle(quota: QuotaSignups) {
-  switch (quota.id) {
-    case WAITLIST:
-      return 'Jonossa';
-    case OPENQUOTA:
-      return 'Avoin kiintiö';
-    default:
-      return quota.title!;
-  }
-}
-
 const SignupList = ({ quota }: Props) => {
   const { signups } = quota;
   const { questions } = useTypedSelector((state) => state.singleEvent.event)!;
   const showQuotas = quota.id === OPENQUOTA || quota.id === WAITLIST;
   return (
     <div className="quota">
-      <h3>{getTitle(quota)}</h3>
+      <h3>{quota.title}</h3>
       {!signups?.length ? (
         <p>Ei ilmoittautumisia.</p>
       ) : (

--- a/src/routes/SingleEvent/components/SignupList/index.tsx
+++ b/src/routes/SingleEvent/components/SignupList/index.tsx
@@ -22,40 +22,42 @@ const SignupList = ({ quota }: Props) => {
       {!signups?.length ? (
         <p>Ei ilmoittautumisia.</p>
       ) : (
-        <table className="table table-condensed table-responsive">
-          <thead>
-            <tr className="active">
-              <th key="position">Sija</th>
-              <th key="attendee" style={{ minWidth: 90 }}>
-                Nimi
-              </th>
-              {_.filter(questions, 'public').map((question) => (
-                <th key={question.id}>
-                  {question.question}
+        <div className="table-responsive">
+          <table className="table table-sm">
+            <thead className="thead-light">
+              <tr>
+                <th key="position">Sija</th>
+                <th key="attendee" style={{ minWidth: 90 }}>
+                  Nimi
                 </th>
+                {_.filter(questions, 'public').map((question) => (
+                  <th key={question.id}>
+                    {question.question}
+                  </th>
+                ))}
+                {showQuotas && (
+                  <th key="quota">
+                    Kiintiö
+                  </th>
+                )}
+                <th key="datetime" style={{ minWidth: 130 }}>
+                  Ilmoittautumisaika
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {signups.map((signup, i) => (
+                <TableRow
+                  index={i + 1}
+                  signup={signup}
+                  showQuota={showQuotas}
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={i}
+                />
               ))}
-              {showQuotas && (
-                <th key="quota">
-                  Kiintiö
-                </th>
-              )}
-              <th key="datetime" style={{ minWidth: 130 }}>
-                Ilmoittautumisaika
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {signups.map((signup, i) => (
-              <TableRow
-                index={i + 1}
-                signup={signup}
-                showQuota={showQuotas}
-                // eslint-disable-next-line react/no-array-index-key
-                key={i}
-              />
-            ))}
-          </tbody>
-        </table>
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/src/routes/SingleEvent/index.tsx
+++ b/src/routes/SingleEvent/index.tsx
@@ -146,18 +146,18 @@ const SingleEvent = ({ match }: Props) => {
           <SignupCountdown beginSignup={beginSignup} />
           <QuotaStatus signups={signupsByQuota} />
         </div>
-        {event.signupsPublic && (
-          <div className="col-xs-12">
-            <h2>Ilmoittautuneet</h2>
-            {signupsByQuota.map((quota) => (
-              <SignupList
-                key={quota.id}
-                quota={quota}
-              />
-            ))}
-          </div>
-        )}
       </div>
+      {event.signupsPublic && (
+        <div className="event-signups">
+          <h2>Ilmoittautuneet</h2>
+          {signupsByQuota.map((quota) => (
+            <SignupList
+              key={quota.id}
+              quota={quota}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/utils/signupUtils.ts
+++ b/src/utils/signupUtils.ts
@@ -39,7 +39,7 @@ export type QuotaSignups = {
 export function getSignupsByQuota(event: AnyEventDetails): QuotaSignups[] {
   const signups = getSignupsAsList(event);
   const quotas = [
-    ...event.quota.map(
+    ...event.quotas.map(
       (quota) => ({
         ...quota,
         signups: signups.filter((signup) => signup.quotaId === quota.id && signup.status === 'in-quota'),
@@ -95,7 +95,10 @@ type FormattedSignup = {
 
 export function getSignupsForAdminList(event: AdminEvent.Details): FormattedSignup[] {
   const signupsArray = getSignupsAsList(event);
-  const sorted = _.orderBy(signupsArray, ['isWaitlist', 'isOpenQuota', 'createdAt']);
+  const sorted = _.orderBy(signupsArray, [
+    (signup) => ['in-quota', 'in-open', 'in-queue', null].indexOf(signup.status),
+    'createdAt',
+  ]);
 
   return sorted.map((signup) => {
     let quotaType = '';

--- a/src/utils/signupUtils.ts
+++ b/src/utils/signupUtils.ts
@@ -2,91 +2,77 @@ import _ from 'lodash';
 import moment from 'moment-timezone';
 
 import { AdminEvent } from '../api/adminEvents';
-import { Event } from '../api/events';
+import { Event, Quota } from '../api/events';
 import { Signup } from '../api/signups';
 
-export const WAITLIST = '__waitlist' as const;
-export const OPENQUOTA = '__open' as const;
+export const WAITLIST = '\x00waitlist';
+export const OPENQUOTA = '\x00open';
 
 type AnyEventDetails = AdminEvent.Details | Event.Details;
-type AnyQuotaDetails = AdminEvent.Details.Quota | Event.Details.Quota;
 type AnySignupDetails = AdminEvent.Details.Signup | Event.Details.Signup;
 type AnyQuestionDetails = AdminEvent.Details.Question | Event.Details.Question;
 
-type EffectiveQuota = AnyQuotaDetails['id'] | typeof WAITLIST | typeof OPENQUOTA;
-
-export type SignupWithQuotaName = AnySignupDetails & {
+export type SignupWithQuota = AnySignupDetails & {
+  quotaId: Quota.Id;
   quotaName: string;
 };
 
+function getSignupsAsList(event: AnyEventDetails): SignupWithQuota[] {
+  return event.quotas.flatMap(
+    (quota) => quota.signups?.map(
+      (signup) => ({
+        ...signup,
+        quotaId: quota.id,
+        quotaName: quota.title,
+      }),
+    ) ?? [],
+  );
+}
+
 export type QuotaSignups = {
-  id: EffectiveQuota;
-  title?: string,
+  id: Quota.Id | typeof OPENQUOTA | typeof WAITLIST;
+  title: string;
   size: number | null;
-  signups: SignupWithQuotaName[];
+  signups: SignupWithQuota[];
 };
 
-export function getSignupsByQuota(event: AnyEventDetails) {
-  let overflow: SignupWithQuotaName[] = [];
-  const quotas: QuotaSignups[] = [];
+export function getSignupsByQuota(event: AnyEventDetails): QuotaSignups[] {
+  const signups = getSignupsAsList(event);
+  const quotas = [
+    ...event.quota.map(
+      (quota) => ({
+        ...quota,
+        signups: signups.filter((signup) => signup.quotaId === quota.id && signup.status === 'in-quota'),
+      }),
+    ),
+  ];
 
-  event.quotas.forEach((quota) => {
-    if (!quota.signups) return;
+  const openSignups = signups.filter((signup) => signup.status === 'in-open');
+  // Open quota is shown if the event has one, or if signups have been assigned there nevertheless.
+  const openQuota = openSignups.length > 0 || event.openQuotaSize > 0 ? [{
+    id: OPENQUOTA as typeof OPENQUOTA,
+    title: 'Avoin kiintiö',
+    size: event.openQuotaSize,
+    signups: openSignups,
+  }] : [];
 
-    const sorted = _.sortBy(quota.signups, 'createdAt').map((signup) => ({
-      ...signup,
-      quotaName: quota.title,
-    }));
-    const overflowAfter = quota.size || quota.signups.length;
+  const queueSignups = signups.filter((signup) => signup.status === 'in-queue');
+  // Queue is shown if signups have been assigned there.
+  const queue = queueSignups.length > 0 ? [{
+    id: WAITLIST as typeof WAITLIST,
+    title: 'Jonossa',
+    size: null,
+    signups: queueSignups,
+  }] : [];
 
-    quotas.push({
-      id: quota.id,
-      title: quota.title,
-      size: quota.size,
-      signups: sorted.slice(0, overflowAfter),
-    });
-    overflow = [...overflow, ...sorted.slice(overflowAfter)];
-  });
-
-  overflow = _.sortBy(overflow, 'createdAt');
-
-  if (event.openQuotaSize > 0) {
-    quotas.push({
-      id: OPENQUOTA,
-      size: event.openQuotaSize,
-      signups: overflow.slice(0, event.openQuotaSize),
-    });
-    overflow = overflow.slice(event.openQuotaSize);
-  }
-
-  quotas.push({
-    id: WAITLIST,
-    size: Infinity,
-    signups: overflow,
-  });
-
-  return quotas;
+  return [
+    ...quotas,
+    ...openQuota,
+    ...queue,
+  ];
 }
 
-type SignupWithQuotaInfo = SignupWithQuotaName & {
-  isWaitlist: boolean;
-  isOpenQuota: boolean;
-};
-
-function getSignupsAsList(event: AnyEventDetails, includeWaitlist = true): SignupWithQuotaInfo[] {
-  const byQuota = getSignupsByQuota(event);
-
-  return _.flatMap(byQuota, ({ id: quotaId, signups }) => {
-    if (!includeWaitlist && quotaId === WAITLIST) return [];
-    return signups.map((signup) => ({
-      ...signup,
-      isWaitlist: quotaId === WAITLIST,
-      isOpenQuota: quotaId === OPENQUOTA,
-    }));
-  });
-}
-
-function getAnswersFromSignup(event: AdminEvent.Details, signup: SignupWithQuotaInfo) {
+function getAnswersFromSignup(event: AdminEvent.Details, signup: AnySignupDetails) {
   const answers: Record<AnyQuestionDetails['id'], string> = {};
 
   event.questions.forEach((question) => {
@@ -107,16 +93,15 @@ type FormattedSignup = {
   createdAt: string;
 };
 
-export function getSignupsForAdminList(event: AdminEvent.Details, includeWaitlist = true): FormattedSignup[] {
-  const signupsArray = getSignupsAsList(event, includeWaitlist);
-
+export function getSignupsForAdminList(event: AdminEvent.Details): FormattedSignup[] {
+  const signupsArray = getSignupsAsList(event);
   const sorted = _.orderBy(signupsArray, ['isWaitlist', 'isOpenQuota', 'createdAt']);
 
   return sorted.map((signup) => {
     let quotaType = '';
-    if (signup.isOpenQuota) {
+    if (signup.status === 'in-open') {
       quotaType = ' (Avoin)';
-    } else if (signup.isWaitlist) {
+    } else if (signup.status === 'in-queue') {
       quotaType = ' (Jonossa)';
     }
     return {


### PR DESCRIPTION
This is a moderately large PR that makes a significant change to the logic of the application in how signups' state is handled. Closes #33.

- Signup state (in quota, in open quota, in queue) is now **computed server-side**. Previously the only place that computed this was the frontend.
- The state is now **stored in the database**.
    - This makes some code less clean and less performant, since we need to recompute and dynamically update the state whenever stuff is touched. Especially, we lock the event's database rows for the recomputation - benchmarking TBD.
    - However, this has a **major** benefit: regardless of what affects the computed statuses of signups, we can now detect it in one place and e.g. send "you got in from the queue" emails.
        - Previously this was very hard, as every place that could affect this (deleting/expiring signups, changing/deleting quotas, ...) would need to delete events one by one and carefully update the next one from the queue.
        - In fact, it wasn't being done at all in multiple places.
        - Previously, if a place was missed, that change was gone. Now we can fix it with just a recompute.
        - The recomputation is idempotent, so extra recomputes don't hurt.
- The code doing status computations is now much cleaner on both sides.

There are also some other changes here:

- Users are now **not** marked as kicked out of events when quota sizes are reduced. This applies both to the open quota and normal quotas.
    - Deleting quotas still deletes signups in them. #41 will improve that with warnings.
    - After this PR there is no way to force accepted users out of quotas.
        - We should discuss if this is a desirable functionality, and what would be the expected behavior when reducing quota sizes. I think we should warn the editor (#41) and then kick users out of events again. It would also be nice to notify these users in some way.
- This now causes an error:
  ```
  users A and B load editor
  user B deletes question/quota Q
  user A saves event with question/quota Q still there
  ```
  This is **much** better than the old behavior, where it would silently re-create Q, and **delete and re-create it on every further save** until a page reload. The optimal solution would be real conflict handling, but that's a can of worms.
- `getEventDetails` was cleaned up, along with its API which now returns more sensible results.
- Some bugfixes.