### PR TITLE
Add confirmation when moving users to queue

### DIFF
--- a/packages/ilmomasiina-backend/src/services/admin/event/errors.ts
+++ b/packages/ilmomasiina-backend/src/services/admin/event/errors.ts
@@ -1,0 +1,41 @@
+/* eslint-disable max-classes-per-file */
+import { FeathersError } from '@feathersjs/errors';
+
+import { Question } from '../../../models/question';
+import { Quota } from '../../../models/quota';
+
+export class QuotaDeleted extends FeathersError {
+  constructor(quotaId: Quota['id']) {
+    super(
+      `quota ${quotaId} was deleted`,
+      'QuotaDeleted',
+      409,
+      'quota-deleted',
+      {},
+    );
+  }
+}
+
+export class QuestionDeleted extends FeathersError {
+  constructor(questionId: Question['id']) {
+    super(
+      `question ${questionId} was deleted`,
+      'QuestionDeleted',
+      409,
+      'question-deleted',
+      {},
+    );
+  }
+}
+
+export class WouldMoveSignupsToQueue extends FeathersError {
+  constructor(count: number) {
+    super(
+      `this change would move ${count} signups into the queue`,
+      'WouldMoveSignupsToQueue',
+      409,
+      'would-move-signups-to-queue',
+      { count },
+    );
+  }
+}

--- a/packages/ilmomasiina-frontend/src/api.ts
+++ b/packages/ilmomasiina-frontend/src/api.ts
@@ -5,6 +5,31 @@ interface FetchOptions {
   accessToken?: string;
 }
 
+export class ApiError extends Error {
+  className?: string;
+  data?: any;
+
+  constructor(data: any) {
+    super(data.message);
+    this.name = 'ApiError';
+    this.className = data.className;
+    this.data = data.data;
+  }
+
+  static async fromResponse(response: Response) {
+    let error = new Error(response.statusText);
+    try {
+      const data = await response.json();
+      if (data.message) {
+        error = new ApiError(data);
+      }
+    } catch (e) {
+      /* fall through */
+    }
+    return error;
+  }
+}
+
 export default async function apiFetch(uri: string, {
   method = 'GET', body, headers, accessToken,
 }: FetchOptions = {}) {
@@ -25,12 +50,7 @@ export default async function apiFetch(uri: string, {
   });
 
   if (response.status > 299) {
-    try {
-      const data = await response.json();
-      throw new Error(data.message || response.statusText);
-    } catch (e) {
-      throw new Error(response.statusText);
-    }
+    throw await ApiError.fromResponse(response);
   }
   return response.json();
 }

--- a/packages/ilmomasiina-frontend/src/modules/editor/actionTypes.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/actionTypes.ts
@@ -4,5 +4,7 @@ export const EVENT_LOAD_FAILED = 'editor/EVENT_LOAD_FAILED';
 export const EVENT_SAVING = 'editor/EVENT_SAVING';
 export const EVENT_SAVE_FAILED = 'editor/EVENT_SAVE_FAILED';
 export const EVENT_SAVED = 'editor/EVENT_SAVED';
+export const MOVE_TO_QUEUE_WARNING = 'editor/MOVE_TO_QUEUE_WARNING';
+export const MOVE_TO_QUEUE_CANCELED = 'editor/MOVE_TO_QUEUE_CANCELED';
 export const EVENT_SLUG_CHECKING = 'editor/EVENT_CHECKING';
 export const EVENT_SLUG_CHECKED = 'editor/EVENT_SLUG_CHECKED';

--- a/packages/ilmomasiina-frontend/src/modules/editor/actions.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/actions.ts
@@ -180,7 +180,7 @@ export const publishNewEvent = (data: EditorEvent) => async (dispatch: DispatchA
 };
 
 export const publishEventUpdate = (
-  id: AdminEvent.Id, data: EditorEvent,
+  id: AdminEvent.Id, data: EditorEvent, moveUsersToQueue: boolean = false,
 ) => async (dispatch: DispatchAction, getState: GetState) => {
   dispatch(saving());
 
@@ -191,7 +191,10 @@ export const publishEventUpdate = (
     const response = await apiFetch(`admin/events/${id}`, {
       accessToken,
       method: 'PATCH',
-      body: cleaned,
+      body: {
+        ...cleaned,
+        moveUsersToQueue,
+      },
     }) as AdminEvent.Details;
     const newFormData = serverEventToEditor(response);
     dispatch(loaded(response, newFormData));

--- a/packages/ilmomasiina-frontend/src/modules/editor/reducer.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/reducer.ts
@@ -5,6 +5,8 @@ import {
   EVENT_SAVING,
   EVENT_SLUG_CHECKED,
   EVENT_SLUG_CHECKING,
+  MOVE_TO_QUEUE_CANCELED,
+  MOVE_TO_QUEUE_WARNING,
   RESET,
 } from './actionTypes';
 import { EditorActions, EditorState } from './types';
@@ -17,6 +19,7 @@ const initialState: EditorState = {
   slugAvailability: null,
   saving: false,
   saveError: false,
+  moveToQueueModal: null,
 };
 
 export default function reducer(
@@ -55,12 +58,24 @@ export default function reducer(
       return {
         ...state,
         saving: true,
+        moveToQueueModal: null,
       };
     case EVENT_SAVE_FAILED:
       return {
         ...state,
         saving: false,
         saveError: true,
+      };
+    case MOVE_TO_QUEUE_WARNING:
+      return {
+        ...state,
+        saving: false,
+        moveToQueueModal: action.payload,
+      };
+    case MOVE_TO_QUEUE_CANCELED:
+      return {
+        ...state,
+        moveToQueueModal: null,
       };
     default:
       return state;

--- a/packages/ilmomasiina-frontend/src/modules/editor/types.d.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/types.d.ts
@@ -7,6 +7,8 @@ import {
   checkingSlugAvailability,
   loaded,
   loadFailed,
+  moveToQueueCanceled,
+  moveToQueueWarning,
   newEvent,
   resetState,
   saveFailed,
@@ -22,6 +24,7 @@ interface EditorState {
   slugAvailability: null | 'checking' | AdminSlug.Check;
   saving: boolean;
   saveError: boolean;
+  moveToQueueModal: { count: number } | null;
 }
 
 type EditorActions =
@@ -32,7 +35,9 @@ type EditorActions =
   | ReturnType<typeof checkingSlugAvailability>
   | ReturnType<typeof slugAvailabilityChecked>
   | ReturnType<typeof saving>
-  | ReturnType<typeof saveFailed>;
+  | ReturnType<typeof saveFailed>
+  | ReturnType<typeof moveToQueueWarning>
+  | ReturnType<typeof moveToQueueCanceled>;
 
 /** Question type for event editor */
 export interface EditorQuestion extends AdminEvent.Update.Question {

--- a/packages/ilmomasiina-frontend/src/routes/Editor/components/MoveToQueueWarning.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/components/MoveToQueueWarning.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { Button, Modal } from 'react-bootstrap';
+
+import { moveToQueueCanceled } from '../../../modules/editor/actions';
+import { useTypedDispatch, useTypedSelector } from '../../../store/reducers';
+
+type Props = {
+  onProceed: () => void;
+};
+
+const MoveToQueueWarning = ({ onProceed }: Props) => {
+  const dispatch = useTypedDispatch();
+  const modal = useTypedSelector((state) => state.editor.moveToQueueModal);
+
+  return (
+    <Modal
+      show={!!modal}
+      onHide={() => dispatch(moveToQueueCanceled())}
+    >
+      <Modal.Header>
+        <Modal.Title>Siirretäänkö ilmoittautumisia jonoon?</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>
+          {'Tekemäsi muutokset kiintiöihin siirtävät vähintään '}
+          {modal?.count || '?'}
+          {' jo kiintiöön päässyttä ilmoittautumista jonoon. Käyttäjille ei ilmoiteta tästä automaattisesti.'}
+        </p>
+        <p>
+          Haluatko varmasti jatkaa?
+        </p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="muted" onClick={() => dispatch(moveToQueueCanceled())}>Peruuta</Button>
+        <Button variant="danger" onClick={onProceed}>Jatka</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default MoveToQueueWarning;

--- a/packages/ilmomasiina-models/src/services/admin/events/update.ts
+++ b/packages/ilmomasiina-models/src/services/admin/events/update.ts
@@ -20,4 +20,5 @@ export interface AdminEventUpdateQuota extends Pick<QuotaAttributes, typeof admi
 export interface AdminEventUpdateBody extends Pick<EventAttributes, typeof adminEventCreateEventAttrs[number]> {
   questions: AdminEventUpdateQuestion[];
   quotas: AdminEventUpdateQuota[];
+  moveSignupsToQueue?: boolean;
 }


### PR DESCRIPTION
Closes #41.

This PR adds a confirmation modal when an admin is trying to save a change to quotas which would move users from quotas (i.e. accepted to the event) into the queue (i.e. out of the event).

The check is performed in the edit transaction while recomputing the signup positions. It is only done when editing events, not on other recomputations, to avoid random errors for users in case the database ever goes out of sync.

Currently, no email is sent to affected users (and the modal mentions that).