### PR TITLE
Add edit conflict resolution for events

### DIFF
--- a/packages/ilmomasiina-backend/src/models/event.ts
+++ b/packages/ilmomasiina-backend/src/models/event.ts
@@ -11,11 +11,14 @@ import { Question } from './question';
 import { Quota } from './quota';
 import { generateRandomId, RANDOM_ID_LENGTH } from './randomId';
 
+// Drop updatedAt so we don't need to define it manually in Event.init()
+interface EventManualAttributes extends Omit<EventAttributes, 'updatedAt'> {}
+
 export interface EventCreationAttributes
-  extends Optional<EventAttributes, 'id' | 'openQuotaSize' | 'description' | 'price' | 'location'
+  extends Optional<EventManualAttributes, 'id' | 'openQuotaSize' | 'description' | 'price' | 'location'
   | 'facebookUrl' | 'webpageUrl' | 'draft' | 'listed' | 'signupsPublic' | 'verificationEmail'> {}
 
-export class Event extends Model<EventAttributes, EventCreationAttributes> implements EventAttributes {
+export class Event extends Model<EventManualAttributes, EventCreationAttributes> implements EventAttributes {
   public id!: string;
   public title!: string;
   public slug!: string;

--- a/packages/ilmomasiina-backend/src/services/admin/event/errors.ts
+++ b/packages/ilmomasiina-backend/src/services/admin/event/errors.ts
@@ -5,13 +5,13 @@ import { Question } from '../../../models/question';
 import { Quota } from '../../../models/quota';
 
 export class EditConflict extends FeathersError {
-  constructor(deletedQuotas: Quota['id'][], deletedQuestions: Question['id'][]) {
+  constructor(updatedAt: Date, deletedQuotas: Quota['id'][], deletedQuestions: Question['id'][]) {
     super(
-      `${deletedQuestions.length} question IDs and ${deletedQuotas.length} quota IDs don't exist`,
+      `the event was updated separately at ${updatedAt.toISOString()}`,
       'EditConflict',
       409,
       'edit-conflict',
-      { deletedQuotas, deletedQuestions },
+      { updatedAt, deletedQuotas, deletedQuestions },
     );
   }
 }

--- a/packages/ilmomasiina-backend/src/services/admin/event/errors.ts
+++ b/packages/ilmomasiina-backend/src/services/admin/event/errors.ts
@@ -4,26 +4,14 @@ import { FeathersError } from '@feathersjs/errors';
 import { Question } from '../../../models/question';
 import { Quota } from '../../../models/quota';
 
-export class QuotaDeleted extends FeathersError {
-  constructor(quotaId: Quota['id']) {
+export class EditConflict extends FeathersError {
+  constructor(deletedQuotas: Quota['id'][], deletedQuestions: Question['id'][]) {
     super(
-      `quota ${quotaId} was deleted`,
-      'QuotaDeleted',
+      `${deletedQuestions.length} question IDs and ${deletedQuotas.length} quota IDs don't exist`,
+      'EditConflict',
       409,
-      'quota-deleted',
-      {},
-    );
-  }
-}
-
-export class QuestionDeleted extends FeathersError {
-  constructor(questionId: Question['id']) {
-    super(
-      `question ${questionId} was deleted`,
-      'QuestionDeleted',
-      409,
-      'question-deleted',
-      {},
+      'edit-conflict',
+      { deletedQuotas, deletedQuestions },
     );
   }
 }

--- a/packages/ilmomasiina-frontend/package-lock.json
+++ b/packages/ilmomasiina-frontend/package-lock.json
@@ -13347,6 +13347,11 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "reselect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.2.tgz",
+      "integrity": "sha512-wg60ebcPOtxcptIUfrr7Jt3h4BR86cCW3R7y4qt65lnNb4yz4QgrXcbSioVsIOYguyz42+XTHIyJ5TEruzkFgQ=="
+    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",

--- a/packages/ilmomasiina-frontend/package.json
+++ b/packages/ilmomasiina-frontend/package.json
@@ -82,6 +82,7 @@
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.4.0",
     "remark-gfm": "^3.0.1",
+    "reselect": "^4.1.2",
     "resolve": "^1.20.0",
     "resolve-url-loader": "^3.1.2",
     "sass-loader": "^10.0.5",

--- a/packages/ilmomasiina-frontend/src/modules/editor/actionTypes.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/actionTypes.ts
@@ -6,5 +6,7 @@ export const EVENT_SAVE_FAILED = 'editor/EVENT_SAVE_FAILED';
 export const EVENT_SAVED = 'editor/EVENT_SAVED';
 export const MOVE_TO_QUEUE_WARNING = 'editor/MOVE_TO_QUEUE_WARNING';
 export const MOVE_TO_QUEUE_CANCELED = 'editor/MOVE_TO_QUEUE_CANCELED';
+export const EDIT_CONFLICT = 'editor/EDIT_CONFLICT';
+export const EDIT_CONFLICT_DISMISSED = 'editor/EDIT_CONFLICT_DISMISSED';
 export const EVENT_SLUG_CHECKING = 'editor/EVENT_CHECKING';
 export const EVENT_SLUG_CHECKED = 'editor/EVENT_SLUG_CHECKED';

--- a/packages/ilmomasiina-frontend/src/modules/editor/actions.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/actions.ts
@@ -49,6 +49,8 @@ export const defaultEvent = (): EditorEvent => ({
 
   draft: true,
   listed: true,
+
+  updatedAt: '',
 });
 
 export const resetState = () => <const>{

--- a/packages/ilmomasiina-frontend/src/modules/editor/reducer.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/reducer.ts
@@ -1,4 +1,6 @@
 import {
+  EDIT_CONFLICT,
+  EDIT_CONFLICT_DISMISSED,
   EVENT_LOAD_FAILED,
   EVENT_LOADED,
   EVENT_SAVE_FAILED,
@@ -19,6 +21,7 @@ const initialState: EditorState = {
   saving: false,
   saveError: false,
   moveToQueueModal: null,
+  editConflictModal: null,
 };
 
 export default function reducer(
@@ -74,6 +77,16 @@ export default function reducer(
       return {
         ...state,
         moveToQueueModal: null,
+      };
+    case EDIT_CONFLICT:
+      return {
+        ...state,
+        editConflictModal: action.payload,
+      };
+    case EDIT_CONFLICT_DISMISSED:
+      return {
+        ...state,
+        editConflictModal: null,
       };
     default:
       return state;

--- a/packages/ilmomasiina-frontend/src/modules/editor/reducer.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/reducer.ts
@@ -13,7 +13,6 @@ import { EditorActions, EditorState } from './types';
 
 const initialState: EditorState = {
   event: null,
-  formData: null,
   isNew: true,
   loadError: false,
   slugAvailability: null,
@@ -33,7 +32,6 @@ export default function reducer(
       return {
         ...state,
         event: action.payload.event,
-        formData: action.payload.formData,
         isNew: action.payload.isNew,
         loadError: false,
         saving: false,

--- a/packages/ilmomasiina-frontend/src/modules/editor/selectors.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/selectors.ts
@@ -1,0 +1,10 @@
+import { createSelector } from 'reselect';
+
+import { AppState } from '../../store/types';
+import { defaultEvent, serverEventToEditor } from './actions';
+
+// eslint-disable-next-line import/prefer-default-export
+export const selectFormData = createSelector(
+  (state: AppState) => state.editor.event,
+  (event) => (!event ? defaultEvent() : serverEventToEditor(event)),
+);

--- a/packages/ilmomasiina-frontend/src/modules/editor/types.d.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/types.d.ts
@@ -16,7 +16,6 @@ import {
 
 interface EditorState {
   event: AdminEvent.Details | null;
-  formData: EditorEvent | null;
   isNew: boolean;
   loadError: boolean;
   slugAvailability: null | 'checking' | AdminSlug.Check;

--- a/packages/ilmomasiina-frontend/src/modules/editor/types.d.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/types.d.ts
@@ -3,6 +3,8 @@ import { AdminSlug } from '@tietokilta/ilmomasiina-models/src/services/admin/slu
 import { Question, Quota } from '@tietokilta/ilmomasiina-models/src/services/events';
 import {
   checkingSlugAvailability,
+  editConflictDetected,
+  editConflictDismissed,
   loaded,
   loadFailed,
   moveToQueueCanceled,
@@ -22,6 +24,7 @@ interface EditorState {
   saving: boolean;
   saveError: boolean;
   moveToQueueModal: { count: number } | null;
+  editConflictModal: EditConflictData | null;
 }
 
 type EditorActions =
@@ -34,7 +37,9 @@ type EditorActions =
   | ReturnType<typeof saving>
   | ReturnType<typeof saveFailed>
   | ReturnType<typeof moveToQueueWarning>
-  | ReturnType<typeof moveToQueueCanceled>;
+  | ReturnType<typeof moveToQueueCanceled>
+  | ReturnType<typeof editConflictDetected>
+  | ReturnType<typeof editConflictDismissed>;
 
 /** Question type for event editor */
 export interface EditorQuestion extends AdminEvent.Update.Question {
@@ -61,4 +66,9 @@ export interface EditorEvent extends Omit<AdminEvent.Update.Body, 'quota'> {
   registrationEndDate: Date | undefined;
   quotas: EditorQuota[];
   useOpenQuota: boolean;
+}
+
+export interface EditConflictData {
+  deletedQuotas: Quota.Id[];
+  deletedQuestions: Quota.Id[];
 }

--- a/packages/ilmomasiina-frontend/src/modules/editor/types.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/types.ts
@@ -16,7 +16,7 @@ import {
   slugAvailabilityChecked,
 } from './actions';
 
-interface EditorState {
+export interface EditorState {
   event: AdminEvent.Details | null;
   isNew: boolean;
   loadError: boolean;
@@ -27,7 +27,7 @@ interface EditorState {
   editConflictModal: EditConflictData | null;
 }
 
-type EditorActions =
+export type EditorActions =
   | ReturnType<typeof resetState>
   | ReturnType<typeof loaded>
   | ReturnType<typeof newEvent>
@@ -42,7 +42,7 @@ type EditorActions =
   | ReturnType<typeof editConflictDismissed>;
 
 /** Question type for event editor */
-export interface EditorQuestion extends AdminEvent.Update.Question {
+export interface EditorQuestion extends Omit<AdminEvent.Update.Question, 'options'> {
   key: Question.Id;
   options: string[];
 }
@@ -52,10 +52,12 @@ export interface EditorQuota extends AdminEvent.Update.Quota {
   key: Quota.Id;
 }
 
-type EditorEventType = 'event' | 'event+signup' | 'signup';
+export type EditorEventType = 'event' | 'event+signup' | 'signup';
 
 /** Root form data type for event editor */
-export interface EditorEvent extends Omit<AdminEvent.Update.Body, 'quota'> {
+export interface EditorEvent extends Omit<
+AdminEvent.Update.Body, 'quotas' | 'questions' | 'date' | 'registrationStartDate' | 'registrationEndDate'
+> {
   eventType: EditorEventType;
 
   date: Date | undefined;
@@ -69,6 +71,7 @@ export interface EditorEvent extends Omit<AdminEvent.Update.Body, 'quota'> {
 }
 
 export interface EditConflictData {
+  updatedAt: string;
   deletedQuotas: Quota.Id[];
   deletedQuestions: Quota.Id[];
 }

--- a/packages/ilmomasiina-frontend/src/routes/Editor/components/EditConflictModal.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/components/EditConflictModal.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+
+import { useFormikContext } from 'formik';
+import { Button, Modal } from 'react-bootstrap';
+
+import { editConflictDismissed, reloadEvent } from '../../../modules/editor/actions';
+import { EditorEvent } from '../../../modules/editor/types';
+import { useTypedDispatch, useTypedSelector } from '../../../store/reducers';
+
+const EditConflictModal = () => {
+  const dispatch = useTypedDispatch();
+  const modal = useTypedSelector((state) => state.editor.editConflictModal);
+
+  const deletedQuestions = modal?.deletedQuestions || [];
+  const deletedQuotas = modal?.deletedQuotas || [];
+
+  const { values: { questions, quotas }, setFieldValue, submitForm } = useFormikContext<EditorEvent>();
+
+  // Another ugly hack. Formik doesn't provide a facility to modify fields and then reliably submit them, due to it
+  // storing its data in an internal useReducer. setFieldValue() followed by submitForm() _seems_ to work, but isn't
+  // guaranteed; therefore, we setFieldValue() here and submitForm() on the next render.
+  const [submitOverwrite, setSubmitOverwrite] = useState(false);
+
+  useEffect(() => {
+    if (submitOverwrite) {
+      setSubmitOverwrite(false);
+      submitForm();
+    }
+  }, [submitOverwrite, submitForm]);
+
+  function overwrite() {
+    setFieldValue(
+      'questions',
+      questions.map((question) => {
+        if (!question.id || !deletedQuestions.includes(question.id)) return question;
+        return {
+          ...question,
+          id: undefined,
+          key: `new-${Math.random()}`,
+        };
+      }),
+    );
+    setFieldValue(
+      'quotas',
+      quotas.map((quota) => {
+        if (!quota.id || !deletedQuotas.includes(quota.id)) return quota;
+        return {
+          ...quota,
+          id: undefined,
+          key: `new-${Math.random()}`,
+        };
+      }),
+    );
+    dispatch(editConflictDismissed());
+    setSubmitOverwrite(true);
+  }
+
+  function revert() {
+    dispatch(reloadEvent());
+    dispatch(editConflictDismissed());
+  }
+
+  return (
+    <Modal
+      show={!!modal}
+      onHide={() => dispatch(editConflictDismissed())}
+      backdrop="static"
+    >
+      <Modal.Header>
+        <Modal.Title>Päällekkäinen muokkaus</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>
+          Toinen käyttäjä tai välilehti on poistanut seuraavat kiintiöt ja/tai kysymykset:
+        </p>
+        <ul>
+          {questions
+            .filter((question) => question.id && deletedQuestions.includes(question.id))
+            .map((question) => (
+              <li key={question.key}>
+                <strong>Kysymys: </strong>
+                {question.question}
+              </li>
+            ))}
+          {quotas
+            .filter((quota) => quota.id && deletedQuotas.includes(quota.id))
+            .map((quota) => (
+              <li key={quota.key}>
+                <strong>Kiintiö: </strong>
+                {quota.title}
+              </li>
+            ))}
+        </ul>
+        <p>
+          Voit tallentaa tapahtuman ja ylikirjoittaa toisen käyttäjän muutokset, tai hylätä tekemäsi
+          muutokset ja jatkaa toisen käyttäjän muokkaamasta tapahtumasta.
+        </p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="muted" onClick={() => dispatch(editConflictDismissed())}>Peruuta</Button>
+        <Button variant="secondary" onClick={revert}>Hylkää muutokset</Button>
+        <Button variant="warning" onClick={overwrite}>Ylikirjoita</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default EditConflictModal;

--- a/packages/ilmomasiina-frontend/src/routes/Editor/components/EditConflictModal.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/components/EditConflictModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { useFormikContext } from 'formik';
+import moment from 'moment-timezone';
 import { Button, Modal } from 'react-bootstrap';
 
 import { editConflictDismissed, reloadEvent } from '../../../modules/editor/actions';
@@ -29,6 +30,9 @@ const EditConflictModal = () => {
   }, [submitOverwrite, submitForm]);
 
   function overwrite() {
+    // Tell the backend we want to overwrite the latest change.
+    setFieldValue('updatedAt', modal!.updatedAt);
+    // We still need to re-create the questions and quotas that were deleted, by removing their old IDs.
     setFieldValue(
       'questions',
       questions.map((question) => {
@@ -71,7 +75,14 @@ const EditConflictModal = () => {
       </Modal.Header>
       <Modal.Body>
         <p>
-          Toinen käyttäjä tai välilehti on poistanut seuraavat kiintiöt ja/tai kysymykset:
+          Toinen käyttäjä tai välilehti on muokannut tätä tapahtumaa
+          {' '}
+          <strong>
+            {modal && moment(modal.updatedAt)
+              .tz('Europe/Helsinki')
+              .format('DD.MM.YYYY HH:mm:ss')}
+          </strong>
+          {deletedQuotas.length || deletedQuestions.length ? ' ja poistanut seuraavat kiintiöt tai kysymykset:' : '.'}
         </p>
         <ul>
           {questions

--- a/packages/ilmomasiina-frontend/src/routes/Editor/components/EditForm.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/components/EditForm.tsx
@@ -1,0 +1,62 @@
+import React, { RefObject, useState } from 'react';
+
+import { FormikProps } from 'formik';
+import { Form } from 'react-bootstrap';
+
+import { EditorEvent } from '../../../modules/editor/types';
+import { EditorSubmitOptions } from '..';
+import BasicDetailsTab from './BasicDetailsTab';
+import EditorTabBody from './EditorTabBody';
+import EditorTabHeader, { EditorTab } from './EditorTabHeader';
+import EditorToolbar from './EditorToolbar';
+import EmailsTab from './EmailsTab';
+import MoveToQueueWarning from './MoveToQueueWarning';
+import QuestionsTab from './QuestionsTab';
+import QuotasTab from './QuotasTab';
+import SignupsTab from './SignupsTab';
+
+type Props = FormikProps<EditorEvent> & {
+  submitOptions: RefObject<EditorSubmitOptions>;
+};
+
+const EditForm = ({ handleSubmit, submitForm, submitOptions }: Props) => {
+  const [activeTab, setActiveTab] = useState<EditorTab>(EditorTab.BASIC_DETAILS);
+
+  function onSubmitClick(asDraft: boolean) {
+    // eslint-disable-next-line no-param-reassign
+    submitOptions.current!.saveAsDraft = asDraft;
+    submitForm();
+  }
+
+  function onMoveToQueueProceed() {
+    // eslint-disable-next-line no-param-reassign
+    submitOptions.current!.allowMoveToQueue = true;
+    submitForm();
+  }
+
+  return (
+    <>
+      <Form onSubmit={handleSubmit}>
+        <EditorToolbar onSubmitClick={onSubmitClick} />
+        <EditorTabHeader activeTab={activeTab} setActiveTab={setActiveTab} />
+
+        <div className="event-editor--valid-notice collapsed">
+          <span>
+            <b>*</b>
+            Tähdellä merkityt kentät ovat pakollisia
+          </span>
+        </div>
+        <div className="tab-content">
+          <EditorTabBody id={EditorTab.BASIC_DETAILS} activeTab={activeTab} component={BasicDetailsTab} />
+          <EditorTabBody id={EditorTab.QUOTAS} activeTab={activeTab} component={QuotasTab} />
+          <EditorTabBody id={EditorTab.QUESTIONS} activeTab={activeTab} component={QuestionsTab} />
+          <EditorTabBody id={EditorTab.EMAILS} activeTab={activeTab} component={EmailsTab} />
+          <EditorTabBody id={EditorTab.SIGNUPS} activeTab={activeTab} component={SignupsTab} />
+        </div>
+      </Form>
+      <MoveToQueueWarning onProceed={onMoveToQueueProceed} />
+    </>
+  );
+};
+
+export default EditForm;

--- a/packages/ilmomasiina-frontend/src/routes/Editor/components/EditForm.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/components/EditForm.tsx
@@ -6,6 +6,7 @@ import { Form } from 'react-bootstrap';
 import { EditorEvent } from '../../../modules/editor/types';
 import { EditorSubmitOptions } from '..';
 import BasicDetailsTab from './BasicDetailsTab';
+import EditConflictModal from './EditConflictModal';
 import EditorTabBody from './EditorTabBody';
 import EditorTabHeader, { EditorTab } from './EditorTabHeader';
 import EditorToolbar from './EditorToolbar';
@@ -55,6 +56,7 @@ const EditForm = ({ handleSubmit, submitForm, submitOptions }: Props) => {
         </div>
       </Form>
       <MoveToQueueWarning onProceed={onMoveToQueueProceed} />
+      <EditConflictModal />
     </>
   );
 };

--- a/packages/ilmomasiina-frontend/src/routes/Editor/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/index.tsx
@@ -1,91 +1,93 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { Formik, FormikHelpers } from 'formik';
-import { Container, Form, Spinner } from 'react-bootstrap';
+import { Container, Spinner } from 'react-bootstrap';
 import { shallowEqual } from 'react-redux';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 import {
-  getEvent, newEvent, publishEventUpdate, publishNewEvent, resetState,
+  getEvent, newEvent, publishEventUpdate, publishNewEvent, resetState, serverEventToEditor,
 } from '../../modules/editor/actions';
+import { selectFormData as selectInitialFormData } from '../../modules/editor/selectors';
 import { EditorEvent } from '../../modules/editor/types';
 import { useTypedDispatch, useTypedSelector } from '../../store/reducers';
-import BasicDetailsTab from './components/BasicDetailsTab';
-import EditorTabBody from './components/EditorTabBody';
-import EditorTabHeader, { EditorTab } from './components/EditorTabHeader';
-import EditorToolbar from './components/EditorToolbar';
-import EmailsTab from './components/EmailsTab';
-import MoveToQueueWarning from './components/MoveToQueueWarning';
-import QuestionsTab from './components/QuestionsTab';
-import QuotasTab from './components/QuotasTab';
-import SignupsTab from './components/SignupsTab';
+import EditForm from './components/EditForm';
 
 import './Editor.scss';
+
+export interface EditorSubmitOptions {
+  saveAsDraft: boolean | undefined;
+  allowMoveToQueue: boolean;
+}
 
 interface MatchParams {
   id: string;
 }
 
-interface EditSignupProps {}
-
-type Props = EditSignupProps & RouteComponentProps<MatchParams>;
+type Props = RouteComponentProps<MatchParams>;
 
 const Editor = ({ history, match }: Props) => {
   const dispatch = useTypedDispatch();
   const {
-    event, formData, isNew, loadError,
-  } = useTypedSelector(
-    (state) => state.editor,
-    shallowEqual,
-  );
+    event, isNew, loadError,
+  } = useTypedSelector((state) => state.editor, shallowEqual);
+  const initialFormData = useTypedSelector(selectInitialFormData);
 
-  const eventId = match.params.id;
-
-  const [activeTab, setActiveTab] = useState<EditorTab>(EditorTab.BASIC_DETAILS);
+  const urlEventId = match.params.id;
+  const urlIsNew = urlEventId === 'new';
 
   useEffect(() => {
-    if (eventId === 'new') {
+    if (urlIsNew) {
       dispatch(newEvent());
     } else {
-      dispatch(getEvent(eventId));
+      dispatch(getEvent(urlEventId));
     }
     return () => {
       dispatch(resetState());
     };
-  }, [dispatch, eventId]);
+  }, [dispatch, urlIsNew, urlEventId]);
 
-  // Ugly hack, but Formik doesn't really give us a clean way to
-  // call setFieldValue("draft", ...) and then submit once that has propagated.
-  const saveAsDraft = useRef<boolean | undefined>();
-  const allowMoveToQueue = useRef<boolean>(false);
+  // Ugly hack, but Formik doesn't really give us a clean way to pass data from submitForm() to onSubmit().
+  // If we call setFieldValue("draft", ...) and then submitForm(), the data won't be propagated.
+  const submitOptions = useRef<EditorSubmitOptions>({
+    saveAsDraft: undefined,
+    allowMoveToQueue: false,
+  });
 
-  async function onSubmit(data: EditorEvent, { setSubmitting }: FormikHelpers<EditorEvent>) {
+  async function onSubmit(data: EditorEvent, { setSubmitting, setFieldValue }: FormikHelpers<EditorEvent>) {
     // Consume the "Proceed, move signups to queue" button click, if any.
-    const moveToQueue = allowMoveToQueue.current;
-    allowMoveToQueue.current = false;
+    const moveToQueue = submitOptions.current.allowMoveToQueue;
+    submitOptions.current.allowMoveToQueue = false;
 
     // Set draft state from last submit button pressed if any, otherwise keep it as-is.
-    const draft = saveAsDraft.current ?? (event?.draft || isNew);
+    const draft = submitOptions.current.saveAsDraft ?? (event?.draft || isNew);
     const modifiedEvent = {
       ...data,
       draft,
     };
 
     try {
+      let saved;
       if (isNew) {
-        const created = await dispatch(publishNewEvent(modifiedEvent));
-        history.push(`${PREFIX_URL}/admin/edit/${created.id}`);
+        saved = await dispatch(publishNewEvent(modifiedEvent));
+        history.push(`${PREFIX_URL}/admin/edit/${saved.id}`);
         toast.success('Tapahtuma luotiin onnistuneesti!', {
           autoClose: 2000,
         });
       } else {
-        const saved = await dispatch(publishEventUpdate(event!.id, modifiedEvent, moveToQueue));
+        saved = await dispatch(publishEventUpdate(event!.id, modifiedEvent, moveToQueue));
         if (saved) {
           toast.success('Muutoksesi tallennettiin onnistuneesti!', {
             autoClose: 2000,
           });
         }
+      }
+      // Update questions/quotas to get IDs from the server
+      if (saved) {
+        const newFormData = serverEventToEditor(saved);
+        setFieldValue('quotas', newFormData.quotas);
+        setFieldValue('questions', newFormData.questions);
       }
     } catch (error) {
       toast.error(
@@ -101,14 +103,14 @@ const Editor = ({ history, match }: Props) => {
       <Container className="event-editor">
         <div className="event-editor--loading-container">
           <h1>Hups, jotain meni pieleen</h1>
-          <p>{`Tapahtumaa id:llä "${eventId}" ei löytynyt`}</p>
+          <p>{`Tapahtumaa id:llä "${urlEventId}" ei löytynyt`}</p>
           <Link to={`${PREFIX_URL}/admin/`}>Palaa tapahtumalistaukseen</Link>
         </div>
       </Container>
     );
   }
 
-  if (!formData) {
+  if (!urlIsNew && !event) {
     return (
       <Container className="event-editor">
         <div className="event-editor--loading-container">
@@ -121,43 +123,10 @@ const Editor = ({ history, match }: Props) => {
   return (
     <Container className="event-editor" role="tablist">
       <Formik
-        initialValues={formData!}
+        initialValues={initialFormData!}
         onSubmit={onSubmit}
       >
-        {({ handleSubmit, submitForm }) => {
-          function onSubmitClick(asDraft: boolean) {
-            saveAsDraft.current = asDraft;
-            submitForm();
-          }
-          function onMoveToQueueProceed() {
-            allowMoveToQueue.current = true;
-            submitForm();
-          }
-
-          return (
-            <>
-              <Form onSubmit={handleSubmit}>
-                <EditorToolbar onSubmitClick={onSubmitClick} />
-                <EditorTabHeader activeTab={activeTab} setActiveTab={setActiveTab} />
-
-                <div className="event-editor--valid-notice collapsed">
-                  <span>
-                    <b>*</b>
-                    Tähdellä merkityt kentät ovat pakollisia
-                  </span>
-                </div>
-                <div className="tab-content">
-                  <EditorTabBody id={EditorTab.BASIC_DETAILS} activeTab={activeTab} component={BasicDetailsTab} />
-                  <EditorTabBody id={EditorTab.QUOTAS} activeTab={activeTab} component={QuotasTab} />
-                  <EditorTabBody id={EditorTab.QUESTIONS} activeTab={activeTab} component={QuestionsTab} />
-                  <EditorTabBody id={EditorTab.EMAILS} activeTab={activeTab} component={EmailsTab} />
-                  <EditorTabBody id={EditorTab.SIGNUPS} activeTab={activeTab} component={SignupsTab} />
-                </div>
-              </Form>
-              <MoveToQueueWarning onProceed={onMoveToQueueProceed} />
-            </>
-          );
-        }}
+        {(props) => <EditForm {...props} submitOptions={submitOptions} />}
       </Formik>
     </Container>
   );

--- a/packages/ilmomasiina-frontend/src/routes/Editor/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/index.tsx
@@ -86,6 +86,7 @@ const Editor = ({ history, match }: Props) => {
       // Update questions/quotas to get IDs from the server
       if (saved) {
         const newFormData = serverEventToEditor(saved);
+        setFieldValue('updatedAt', saved.updatedAt);
         setFieldValue('quotas', newFormData.quotas);
         setFieldValue('questions', newFormData.questions);
       }

--- a/packages/ilmomasiina-models/src/models/event.ts
+++ b/packages/ilmomasiina-models/src/models/event.ts
@@ -15,4 +15,5 @@ export default interface EventAttributes {
   listed: boolean;
   signupsPublic: boolean;
   verificationEmail: string | null;
+  updatedAt: Date;
 }

--- a/packages/ilmomasiina-models/src/services/admin/events/update.ts
+++ b/packages/ilmomasiina-models/src/services/admin/events/update.ts
@@ -21,4 +21,5 @@ export interface AdminEventUpdateBody extends Pick<EventAttributes, typeof admin
   questions: AdminEventUpdateQuestion[];
   quotas: AdminEventUpdateQuota[];
   moveSignupsToQueue?: boolean;
+  updatedAt: string;
 }

--- a/packages/ilmomasiina-models/src/services/events/details.ts
+++ b/packages/ilmomasiina-models/src/services/events/details.ts
@@ -27,6 +27,7 @@ export const adminEventGetEventAttrs = [
   'draft',
   'listed',
   'verificationEmail',
+  'updatedAt',
 ] as const;
 
 // Attributes included in results for Question instances.


### PR DESCRIPTION
This PR adds edit conflict resolution to the event editor. When an event has been updated elsewhere after it was loaded into the editor, saving presents the user with options to either discard their own edits, or overwrite the changes made elsewhere:
![image](https://user-images.githubusercontent.com/8439661/140629516-61fc66e6-f55c-4fe0-96f2-6f3687fca550.png)

It would be wonderful if we didn't need to care about edit conflicts. The most pressing issue with them is what to do when questions/quotas are deleted elsewhere, but the editor still tries to keep them in the update.

We _could_ transparently re-create the deleted questions/quotas with a new ID, but that still won't bring back answers/signups in them. I personally think that it's worth it to give the user the option here.

Now, after writing the code to do that, it was a very small change to add full conflict detection based on the update timestamps. (Theoretically, there's room for error as the timestamp is only accurate to 1 second, but it only applies if an event is saved, another user loads the editor, and then another save happens within the same second.)

Finally, this PR has minor code cleanup and fixes #51.