### PR TITLE
Update container setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules/
+packages/*/node_modules/
+packages/*/build/
+packages/*/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,6 @@ FROM node:12.20.1-alpine
 # Default to production
 ENV NODE_ENV=production
 
-# Move frontend files to a more accessible location
-ENV FRONTEND_FILES_PATH=/opt/ilmomasiina/frontend
-
 WORKDIR /opt/ilmomasiina
 RUN adduser -D masiina
 USER masiina

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,41 @@
-FROM node:8.9.4-alpine
+# Build stage:
+FROM node:12.20.1-alpine as builder
 
-ADD . /opt/ilmomasiina
+COPY . /opt/ilmomasiina
 WORKDIR /opt/ilmomasiina
-RUN adduser -D athene
-RUN chown -R athene /opt/ilmomasiina
-USER athene
-RUN npm install
-CMD npm start
+
+RUN npm ci
+RUN npx lerna bootstrap
+
+# Build all packages
+RUN npm run build
+
+# Replace ilmomasiina-models src with compiled js files
+RUN rm -r /opt/ilmomasiina/packages/ilmomasiina-models/src
+RUN mv /opt/ilmomasiina/packages/ilmomasiina-models/dist /opt/ilmomasiina/packages/ilmomasiina-models/src
+
+# Bundle frontend build to backend
+RUN mv /opt/ilmomasiina/packages/ilmomasiina-frontend/build /opt/ilmomasiina/packages/ilmomasiina-backend/dist/frontend
+
+# Bundle node_modules to dist
+RUN cp -rL /opt/ilmomasiina/packages/ilmomasiina-backend/node_modules \
+    /opt/ilmomasiina/packages/ilmomasiina-backend/dist/node_modules
+
+# Main stage:
+FROM node:12.20.1-alpine
+
+# Default to production
+ENV NODE_ENV=production
+
+# Move frontend files to a more accessible location
+ENV FRONTEND_FILES_PATH=/opt/ilmomasiina/frontend
+
+WORKDIR /opt/ilmomasiina
+RUN adduser -D masiina
+USER masiina
+
+# Copy built backend from build stage
+COPY --from=builder --chown=masiina:masiina /opt/ilmomasiina/packages/ilmomasiina-backend/dist /opt/ilmomasiina
+
+# Start server
+CMD node bin/server.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage:
-FROM node:12-alpine as builder
+FROM node:14-alpine as builder
 
 # Copy source files
 COPY . /opt/ilmomasiina
@@ -12,7 +12,7 @@ RUN npm ci && npm run bootstrap
 RUN npm run build
 
 # Main stage:
-FROM node:12-alpine
+FROM node:14-alpine
 
 # Default to production
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM node:12.20.1-alpine as builder
 COPY . /opt/ilmomasiina
 WORKDIR /opt/ilmomasiina
 
+# Install dependencies (bootstraps lerna via postinstall script)
 RUN npm ci
-RUN npx lerna bootstrap
 
 # Build all packages
 RUN npm run build

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,6 +28,5 @@ COPY packages/ilmomasiina-models/package*.json \
 
 ENV NODE_ENV=development
 
-# Install dependencies & bootstrap lerna
+# Install dependencies (bootstraps lerna via postinstall script)
 RUN npm install
-RUN npx lerna bootstrap

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,10 +1,10 @@
 # This Dockerfile is intended for development use only.
 
-# Only the files required to bootstrap the project will be copied to the container
-# Also the node modules will be installed at build phase and included to the container image.
-# All sources and other files are intended to be provided using bind mounts.
+# Only the files required to bootstrap the project will be copied to the container.
+# Node modules will be installed at the build phase and included in the container image.
+# Sources and other files are intended to be provided using bind mounts.
 
-FROM node:12.20.1-alpine
+FROM node:12-alpine
 
 WORKDIR /opt/ilmomasiina
 
@@ -14,12 +14,12 @@ COPY .eslint* .postcssrc lerna.json package*.json ./
 # Copy static resources from each package
 COPY packages/ilmomasiina-frontend/package*.json \
      packages/ilmomasiina-frontend/tsconfig.json \
-     packages/ilmomasiina-frontend/eslint* \
+     packages/ilmomasiina-frontend/.eslint* \
      packages/ilmomasiina-frontend/
 
 COPY packages/ilmomasiina-backend/package*.json \
      packages/ilmomasiina-backend/tsconfig.json \
-     packages/ilmomasiina-backend/eslint* \
+     packages/ilmomasiina-backend/.eslint* \
      packages/ilmomasiina-backend/
 
 COPY packages/ilmomasiina-models/package*.json \
@@ -28,5 +28,5 @@ COPY packages/ilmomasiina-models/package*.json \
 
 ENV NODE_ENV=development
 
-# Install dependencies (bootstraps lerna via postinstall script)
-RUN npm install
+# Install dependencies (we're running as root, so the postinstall script doesn't run automatically)
+RUN npm install && npm run bootstrap

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,33 @@
+# This Dockerfile is intended for development use only.
+
+# Only the files required to bootstrap the project will be copied to the container
+# Also the node modules will be installed at build phase and included to the container image.
+# All sources and other files are intended to be provided using bind mounts.
+
+FROM node:12.20.1-alpine
+
+WORKDIR /opt/ilmomasiina
+
+# Copy static resources from the repository root
+COPY .eslint* .postcssrc lerna.json package*.json ./
+
+# Copy static resources from each package
+COPY packages/ilmomasiina-frontend/package*.json \
+     packages/ilmomasiina-frontend/tsconfig.json \
+     packages/ilmomasiina-frontend/eslint* \
+     packages/ilmomasiina-frontend/
+
+COPY packages/ilmomasiina-backend/package*.json \
+     packages/ilmomasiina-backend/tsconfig.json \
+     packages/ilmomasiina-backend/eslint* \
+     packages/ilmomasiina-backend/
+
+COPY packages/ilmomasiina-models/package*.json \
+     packages/ilmomasiina-models/tsconfig.json \
+     packages/ilmomasiina-models/
+
+ENV NODE_ENV=development
+
+# Install dependencies & bootstrap lerna
+RUN npm install
+RUN npx lerna bootstrap

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@
 # Node modules will be installed at the build phase and included in the container image.
 # Sources and other files are intended to be provided using bind mounts.
 
-FROM node:12-alpine
+FROM node:14-alpine
 
 WORKDIR /opt/ilmomasiina
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ See the [docs](docs/README.md) folder.
 
 ## Requirements
 
-- Docker: 17.04.0+
-- docker-compose or Compose V2 (included in the latest releases of docker-cli)
-- Node.js: 14+
-- npm: 6+
+- If using Docker:
+   - Docker: 17.04.0+
+   - docker-compose or Compose V2 (included in the latest releases of docker-cli)
+- For development, or if running without Docker:
+   - Node.js: 14+
+   - npm: 6+
 
-> To run the project (dev or production), only Docker and Docker Compose are required.
-> Having also Node.js and npm installed locally makes the development easier.
+To run the project (dev or production), only Docker and Docker Compose are required.
+For actual development, you'll want to have Node.js and npm installed locally in order to manage dependencies.
 
 <!--
 ### Create fake data
@@ -61,24 +63,43 @@ Only follow this if you don't use the Docker container.
 7. Follow Mac instructions step 6
 -->
 
-## Getting started
+## Production setup
 
-### For developers
-1. Create a `.env` file at the root of this repository.
-   For the contents of the .env file, take a look at [.env.example](./.env.example).
-2. Run `npm install` to install packages (this also triggers lerna bootstrap via postinstall script).
+TODO. (This file has lots of outdated information as comments.)
 
-The more detailed introduction can be read from [documentation](docs/README.md).
+## For developers
 
-### Running the development version
-> Development setup is built using docker and docker compose. The [compose file for dev setup](./docker-compose.yml) is
-> located at the root of this repository, and it contains a pre-configured postgres server so external database server
-> is not required.
+See the [documentation](docs/README.md) for more information.
 
-1. Create a `.env` file (*see instructions from the For developers section*).
-2. Go to the repository root and run `docker-compose up`.
-   This builds the dev container and starts ilmomasiina to listen at [http://localhost:3000](http://localhost:3000).
+### Development setup using Docker Compose
 
+The entire development setup can be run within Docker using Docker Compose. The
+[docker-compose dev setup](./docker-compose.yml) is located at the root of this repository, and contains a
+pre-configured Postgres server, so an external database server is not required.
+
+1. Create a `.env` file at the root of this repository. You can copy [.env.example](./.env.example) to begin.
+2. Go to the repository root and run `docker-compose up`. This builds the dev container and starts the frontend and
+   backend servers in parallel.
+3. Access the app at <http://localhost:3000>.
+
+Due to how the dev Docker is set up, you will need to rebuild the development image if you change the dependencies,
+package.json or ESLint configs.
+
+### Non-containerized development setup
+
+You can also run the development server outside Docker.
+
+1. Install Postgres or MySQL. You can use Docker for this. SQLite may also work. but is not currently tested.
+2. Create a `.env` file at the root of this repository. You can copy [.env.example](./.env.example) to begin.
+3. Run `npm install` to install Lerna and other global dependencies. The postinstall script should automatically run
+   `lerna bootstrap` to setup cross-dependencies between packages and install package dependencies.
+4. Run `npm start`. This will start the frontend and backend dev servers in parallel.
+   - If you want cleaner output, you can run `npm start` separately in `packages/ilmomasiina-frontend` and
+     `packages/ilmomasiina-backend`.
+   - Currently, there is no way to run the Webpack development server directly within the backend process.
+5. Access the app at <http://localhost:3000>.
+
+<!-- TODO
 ### Creating first admin user
 > By default, only logged-in admin users can create new admin users using the `/admin` endpoint.
 > To create the first one, admin registration needs to be allowed.
@@ -143,3 +164,4 @@ git pull otax/master
 npm run compile
 pm2 restart prod-server
 ```
+-->

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # Ilmomasiina
 
-Ilmomasiina is the event registration system originally created by Athene, forked by Tietokilta and currently under heavy development for our new site. Once finished, it will be available for all organizations to use, along with migration tools from the Athene-made version.
+Ilmomasiina is the event registration system originally created by Athene, forked by Tietokilta and currently under
+heavy development for our new site. Once finished, it will be available for all organizations to use, along with
+migration tools from the Athene-made version.
 
-The latest development version is in the `dev` branch. **Please note that the code is currently in alpha phase.** It likely has major bugs, and easy migrations will not be provided between versions until we reach beta.
+The latest development version is in the `dev` branch. **Please note that the code is currently in alpha phase.**
+It likely has major bugs, and easy migrations will not be provided between versions until we reach beta.
 
 ## Contributing
 
-Progress and planning is tracked in GitHub issues. Please see and update the [project board](https://github.com/Tietokilta/ilmomasiina/projects/1) for ongoing work.
+Progress and planning is tracked in GitHub issues.
+Please see and update the [project board](https://github.com/Tietokilta/ilmomasiina/projects/1) for ongoing work.
 
-All help is appreciated. Please contact @PurkkaKoodari or another member of Tietokilta's Digitoimikunta if you wish to actively help with development &ndash; there are still major changes to be done that may conflict with yours. Start by reading the [docs](docs/README.md) to get familiar with the project.
+All help is appreciated. Please contact @PurkkaKoodari or another member of Tietokilta's Digitoimikunta if you wish to
+actively help with development &ndash; there are still major changes to be done that may conflict with yours.
+Start by reading the [docs](docs/README.md) to get familiar with the project.
 
 ## Documentation
 
@@ -16,32 +22,32 @@ See the [docs](docs/README.md) folder.
 
 ## Requirements
 
-- Node.js 14
-- npm 6
-- MySQL or MariaDB (latest, older supported versions unknown)
+- Docker: 17.04.0+
+- docker-compose or Compose V2 (included in the latest releases of docker-cli)
+- Node.js: 14+
+- npm: 6+
 
-Containerization for these is in progress.
+> To run the project (dev or production), only Docker and Docker Compose are required.
+> Having also Node.js and npm installed locally makes the development easier.
 
 <!--
-## Using Docker container
-In project root directory
-```bash
-docker-compose up
-```
-This should build and run the environment so that it is accesible at [localhost:3000](http://localhost:3000). You will need to create an `.env` file in project root (see [ENV.md](ENV.md)).
-
 ### Create fake data
-Use `docker exec ilmomasiina_backend_1 npm run create-fake-data` to create some data to dockerized Ilmomasiina. The server does not like an empty database, so this is a really good idea to do when first starting the server.
+Use `docker exec ilmomasiina_backend_1 npm run create-fake-data` to create some data to dockerized Ilmomasiina.
+The server does not like an empty database, so this is a really good idea to do when first starting the server.
 -->
+
+<!--
 ## MySQL Setup
-<!--Only follow this if you don't use the Docker container.-->
+Only follow this if you don't use the Docker container.
 
 ### Mac
 1. Install `mysql` (8.x) with Homebrew (https://gist.github.com/nrollr/3f57fc15ded7dddddcc4e82fe137b58e)
 2. Start the mysql service with `brew services start mysql`
 3. Open the mysql terminal with `mysql -u root`
-4. In the mysql terminal, create a new user e.g. `CREATE USER 'juuso'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password';`
-5. Fix permissions (this is probably too permissive, but it works): `GRANT ALL PRIVILEGES ON *.* TO 'sampo'@'localhost' WITH GRANT OPTION;`
+4. In the mysql terminal, create a new user e.g.
+   `CREATE USER 'juuso'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password';`
+5. Fix permissions (this is probably too permissive, but it works):
+   `GRANT ALL PRIVILEGES ON *.* TO 'sampo'@'localhost' WITH GRANT OPTION;`
 6. Type `exit` to exit the mysql terminal, and sign in with your new user e.g. `mysql -u juuso -p password`
 7. Create the `ilmomasiina` database with `CREATE DATABASE ilmomasiina;`
 
@@ -53,43 +59,53 @@ Use `docker exec ilmomasiina_backend_1 npm run create-fake-data` to create some 
 5. Fix permissions (this is probably too permissive, but it works): `GRANT ALL PRIVILEGES ON *.* TO 'sampo'@'localhost' WITH GRANT OPTION;`
 6. Exit with `exit` and sign in with your new user e. g. `mysql -u juuso -p` (don't use `mysql -u juuso -p password`)
 7. Follow Mac instructions step 6
+-->
 
 ## Getting started
-If you are using the Docker container, only follow step 1 as rest are automatically executed.
 
-1. Create an `.env` file at the root of the project. For the contents of the .env file, check [ENV.MD](./ENV.MD)
-2. `npm install`
-3. **(IMPORTANT)** `npx lerna bootstrap`
-4. `npm start`
+### For developers
+1. Create a `.env` file at the root of this repository.
+   For the contents of the .env file, take a look at [.env.example](./.env.example).
+2. Run `npm install` to install packages (this also triggers lerna bootstrap via postinstall script).
 
-**Optional**: You can create mockup data for development by running `npm run create-fake-data`. During development, database can be resetted with `npm run reset-db`.
+The more detailed introduction can be read from [documentation](docs/README.md).
 
-### Troubleshooting (Ubuntu)
-If `npm start` gives error `Error: You must provide a 'secret' in your authentication configuration`, it probably means that the `.env` file is not loaded correctly. A quick fix for this is to run `source .env`.
+### Running the development version
+> Development setup is built using docker and docker compose. The [compose file for dev setup](./docker-compose.yml) is
+> located at the root of this repository, and it contains a pre-configured postgres server so external database server
+> is not required.
+
+1. Create a `.env` file (*see instructions from the For developers section*).
+2. Go to the repository root and run `docker-compose up`.
+   This builds the dev container and starts ilmomasiina to listen at [http://localhost:3000](http://localhost:3000).
+
+### Creating first admin user
+> By default, only logged-in admin users can create new admin users using the `/admin` endpoint.
+> To create the first one, admin registration needs to be allowed.
+
+Allow admin registration temporarily by adding this line to the `.env` file:
+```
+ADMIN_REGISTRATION_ALLOWED=true
+```
+
+If the Ilmomasiina was already running, restart it to apply the new env configuration.
+
+Now, create a new user with POST request to `/admin`.
+Below is an example using curl:
+```
+curl 'http://localhost:3000/api/users' \
+     -H 'Content-Type: application/json' \
+     --data-binary '{ "email": "ville@athene.fi", "password": "password" }'
+```
+
+**Important**: Disallow admin user creation by removing the previously added line from the `.env` file and restarting
+the docker containers.
 
 ## Mailgun setup
 
 Mailgun provides 10 000 free messages per month which is suitable for small projects. With minor changes sending mail could be also done via Sendgrid. Using your own mail server gets you labelled as spam pretty fast.
 
 Add mailgun credentials to .env configuration.
-
-### Create first admin user
-
-Add this line to .env configuration.
-
-```
-ADMIN_REGISTRATION_ALLOWED=true
-```
-
-Create new user with POST request.
-
-```
-curl 'http://localhost:3000/api/users' -H 'Content-Type: application/json' --data-binary '{ "email": "ville@athene.fi", "password": "password" }'
-```
-
-**Important**: Disallow admin user creation by removing the line.
-
-By default, only logged in admin users can create new admin users (via `/admin`).
 
 ## Production
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,7 +24,10 @@ services:
       - database
     environment:
       - DB_HOST=database
-      - NODE_ENV=development  # TODO: Change to 'production'
+      - NODE_ENV=production
+      - ENFORCE_HTTPS=false
+      # When deploying to production, either set ENFORCE_HTTPS true (default) or
+      # configure the reverse proxy to enforce HTTPS communication with the clients.
     env_file:
       - .env
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,39 @@
+version: '3.2'
+
+# This compose file demonstrates how Ilmomasiina could be run in a production environment.
+
+# This compose file serves Ilmomasiina at http://localhost:8000.
+# Env variables from .env file (in the repository root) will be used by docker compose and passed to the container.
+# Remember to create your own .env file (see .env.example)!
+
+services:
+  database:
+    image: postgres:latest
+    restart: always
+    environment:
+      - POSTGRES_PASSWORD=$DB_PASSWORD
+      - POSTGRES_USER=$DB_USER
+      - POSTGRES_DB=$DB_DATABASE
+
+  ilmomasiina:
+    build:
+      context: .
+      dockerfile: "Dockerfile"
+    restart: always
+    depends_on:
+      - database
+    environment:
+      - DB_HOST=database
+      - NODE_ENV=development  # TODO: Change to 'production'
+    env_file:
+      - .env
+    ports:
+      - "8000:3000"
+    volumes:
+    - "frontend:/opt/ilmomasiina/frontend"
+
+volumes:
+  frontend:
+    # Contains static files of the ilmomasiina-frontend.
+    # To achieve better performance under high loads, these files
+    # can be served using a more performant web server or even a CDN.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,13 @@ version: '3.2'
 
 # This compose file is for development use only – Do not use this in production!
 
-# This compose file builds ilmomasiina and serves it at http://localhost:3000.
+# This compose file builds Ilmomasiina and serves it at http://localhost:3000.
 # For easier development, it provides hot reloading by utilizing bind mounts.
+# You will still need to rebuild if you update the project's dependencies.
 
-# The env vars from .env file (in repository root) will be used by docker compose and passed to the containers.
+# Env vars from the .env file (in repository root) will be used by docker-compose and passed to the containers.
 # Remember to create your own .env file (see .env.example)!
+# The database will use the DB_USER, DB_PASSWORD and DB_DATABASE provided by you.
 
 services:
   database:
@@ -21,11 +23,12 @@ services:
     build:
       context: .
       dockerfile: "Dockerfile.dev"
-    command: "npx lerna run --parallel start:dev"
+    command: "npm start"
     restart: always
     depends_on:
       - database
     environment:
+      - DB_DIALECT=postgres
       - DB_HOST=database
       - NODE_ENV=development
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,53 @@
-version: '3'
+version: '3.2'
+
+# This compose file is for development use only – Do not use this in production!
+
+# This compose file builds ilmomasiina and serves it at http://localhost:3000.
+# For easier development, it provides hot reloading by utilizing bind mounts.
+
+# The env vars from .env file (in repository root) will be used by docker compose and passed to the containers.
+# Remember to create your own .env file (see .env.example)!
 
 services:
-    database:
-        image: mysql:8
-        command: --default-authentication-plugin=mysql_native_password
-        env_file:
-            - .env
-    backend:
-        # Use Dockerfile from root directory
-        build: .
-        environment: 
-            - MYSQL_HOST=database
-        env_file:
-            - .env
-        ports:
-            - "3000:3000"
+  database:
+    image: postgres:latest
+    restart: always
+    environment:
+      - POSTGRES_PASSWORD=$DB_PASSWORD
+      - POSTGRES_USER=$DB_USER
+      - POSTGRES_DB=$DB_DATABASE
+
+  ilmomasiina-dev:
+    build:
+      context: .
+      dockerfile: "Dockerfile.dev"
+    command: "npx lerna run --parallel start:dev"
+    restart: always
+    depends_on:
+      - database
+    environment:
+      - DB_HOST=database
+      - NODE_ENV=development
+    env_file:
+      - .env
+    volumes:
+      - type: bind
+        source: ./packages/ilmomasiina-models/src
+        target: /opt/ilmomasiina/packages/ilmomasiina-models/src
+      - type: bind
+        source: ./packages/ilmomasiina-frontend/config
+        target: /opt/ilmomasiina/packages/ilmomasiina-frontend/config
+      - type: bind
+        source: ./packages/ilmomasiina-frontend/public
+        target: /opt/ilmomasiina/packages/ilmomasiina-frontend/public
+      - type: bind
+        source: ./packages/ilmomasiina-frontend/scripts
+        target: /opt/ilmomasiina/packages/ilmomasiina-frontend/scripts
+      - type: bind
+        source: ./packages/ilmomasiina-frontend/src
+        target: /opt/ilmomasiina/packages/ilmomasiina-frontend/src
+      - type: bind
+        source: ./packages/ilmomasiina-backend/src
+        target: /opt/ilmomasiina/packages/ilmomasiina-backend/src
+    ports:
+      - "3000:3000"

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -3,7 +3,10 @@
 The project uses [Lerna](https://lerna.js.org/) to manage the code in separate packages. This allows for cleaner code
 and package files.
 
-To prepare for development, run `npx lerna bootstrap`.
+To prepare for development, lerna must be bootstrapped. In this project, lerna bootstrapping is implemented using npm
+*postinstall* script. Running `npm install` or `npm ci` will automatically bootstrap lerna once packages are installed.
+To bootstrap lerna manually, run `npx lerna bootstrap`.
+
 The project is configured to run development servers for the frontend and backend with `npm start`.
 
 ## Packages

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -3,11 +3,15 @@
 The project uses [Lerna](https://lerna.js.org/) to manage the code in separate packages. This allows for cleaner code
 and package files.
 
-To prepare for development, lerna must be bootstrapped. In this project, lerna bootstrapping is implemented using npm
-*postinstall* script. Running `npm install` or `npm ci` will automatically bootstrap lerna once packages are installed.
-To bootstrap lerna manually, run `npx lerna bootstrap`.
+To prepare for development, Lerna must bootstrap the cross-dependencies between projects. This is done automatically
+using a npm *postinstall* script. Running `npm install` or `npm ci` will automatically run `lerna bootstrap` once
+packages are installed. To re-run bootstrapping manually, run `npm run bootstrap`.
 
-The project is configured to run development servers for the frontend and backend with `npm start`.
+The project is configured to run development servers for the frontend and backend with `npm start`. In development, the
+Webpack development server serves the frontend and proxies API calls to the backend server.
+
+In production, the backend server can optionally serve the compiled frontend bundle, but ideally a separate reverse
+proxy such as Nginx is used for this purpose.
 
 ## Packages
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "postinstall": "lerna bootstrap",
+    "bootstrap": "lerna bootstrap",
     "clean": "lerna run clean",
     "build": "lerna run build",
     "start": "lerna run --parallel start",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-alpha1",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.1",
+    "node": "^14.19.0",
     "npm": "^6.14.13"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "npm": "^6.14.13"
   },
   "scripts": {
+    "postinstall": "lerna bootstrap",
     "clean": "lerna run clean",
     "build": "lerna run build",
     "start": "lerna run --parallel start",

--- a/packages/ilmomasiina-backend/package.json
+++ b/packages/ilmomasiina-backend/package.json
@@ -11,7 +11,8 @@
     "start:dev": "bnr start:dev",
     "start:prod": "bnr start:prod",
     "stop:prod": "bnr stop:prod",
-    "monit:prod": "bnr monit:prod"
+    "monit:prod": "bnr monit:prod",
+    "build": "bnr build"
   },
   "betterScripts": {
     "start:dev": {
@@ -34,6 +35,9 @@
     },
     "monit:prod": {
       "command": "pm2 monit"
+    },
+    "build": {
+      "command": "tsc --build"
     }
   },
   "dependencies": {

--- a/packages/ilmomasiina-backend/src/app.ts
+++ b/packages/ilmomasiina-backend/src/app.ts
@@ -42,8 +42,8 @@ if (config.nodeEnv === 'development') {
     next(error);
   });
   app.use(express.errorHandler());
-} else {
-  // Production: enforce HTTPS
+} else if (config.nodeEnv === 'production' && config.enforceHTTPS) {
+  // Enforce HTTPS connections
   app.use(enforce.HTTPS({ trustProtoHeader: true }));
 }
 

--- a/packages/ilmomasiina-backend/src/app.ts
+++ b/packages/ilmomasiina-backend/src/app.ts
@@ -49,10 +49,12 @@ if (config.nodeEnv === 'development') {
 
 app.use(historyApiFallback());
 
-// Serving frontend files by default. Ideally these files should be served by
-// the web server and not the app server, but this helps to demo the
-// server in production.
-console.log(`PATH: ${config.frontedFilesPath}`);
-app.use(express.static(config.frontedFilesPath));
+// Serving frontend files if frontedFilesPath is defined (not null).
+// Ideally these files should be served by a web server and not the app server,
+// but this helps to demo the server in production.
+if (config.frontedFilesPath) {
+  console.info(`Serving frontend files from '${config.frontedFilesPath}'`);
+  app.use(express.static(config.frontedFilesPath));
+}
 
 export = app;

--- a/packages/ilmomasiina-backend/src/app.ts
+++ b/packages/ilmomasiina-backend/src/app.ts
@@ -42,19 +42,19 @@ if (config.nodeEnv === 'development') {
     next(error);
   });
   app.use(express.errorHandler());
-} else if (config.nodeEnv === 'production' && config.enforceHTTPS) {
+} else if (config.nodeEnv === 'production' && config.enforceHttps) {
   // Enforce HTTPS connections
   app.use(enforce.HTTPS({ trustProtoHeader: true }));
 }
 
 app.use(historyApiFallback());
 
-// Serving frontend files if frontedFilesPath is defined (not null).
+// Serving frontend files if frontendFilesPath is not null.
 // Ideally these files should be served by a web server and not the app server,
-// but this helps to demo the server in production.
-if (config.frontedFilesPath) {
-  console.info(`Serving frontend files from '${config.frontedFilesPath}'`);
-  app.use(express.static(config.frontedFilesPath));
+// but this helps run a low-effort server.
+if (config.frontendFilesPath) {
+  console.info(`Serving frontend files from '${config.frontendFilesPath}'`);
+  app.use(express.static(config.frontendFilesPath));
 }
 
 export = app;

--- a/packages/ilmomasiina-backend/src/app.ts
+++ b/packages/ilmomasiina-backend/src/app.ts
@@ -5,7 +5,6 @@ import historyApiFallback from 'connect-history-api-fallback';
 import { NextFunction } from 'express';
 import enforce from 'express-sslify';
 import cron from 'node-cron';
-import path from 'path';
 
 import config from './config';
 import anonymizeOldSignups from './cron/anonymizeOldSignups';
@@ -50,10 +49,10 @@ if (config.nodeEnv === 'development') {
 
 app.use(historyApiFallback());
 
-// Serving ~/dist by default. Ideally these files should be served by
+// Serving frontend files by default. Ideally these files should be served by
 // the web server and not the app server, but this helps to demo the
 // server in production.
-const frontendPath = path.dirname(require.resolve('@tietokilta/ilmomasiina-frontend/build/index.html'));
-app.use(express.static(frontendPath));
+console.log(`PATH: ${config.frontedFilesPath}`);
+app.use(express.static(config.frontedFilesPath));
 
 export = app;

--- a/packages/ilmomasiina-backend/src/config.ts
+++ b/packages/ilmomasiina-backend/src/config.ts
@@ -35,6 +35,8 @@ const config = {
 
   dockerCompose: process.env.DOCKER_COMPOSE === 'true',
 
+  enforceHTTPS: !(process.env.ENFORCE_HTTPS === 'false'),
+
   clearDbUrl: process.env.CLEARDB_DATABASE_URL || null,
   dbDialect: process.env.DB_DIALECT,
   dbUser: process.env.DB_USER,
@@ -106,6 +108,16 @@ if (config.adminRegistrationAllowed) {
     + 'WARNING!\nAdmin registration is enabled, meaning anyone can register an administrator account.\n'
     + 'After creating your initial administrator account, make sure to set ADMIN_REGISTRATION_ALLOWED=false.\n'
     + '----------------------------------------------------',
+  );
+}
+
+if (config.enforceHTTPS) {
+  console.info('Enforcing HTTPS connections');
+} else if (config.nodeEnv === 'production') {
+  console.warn(
+    'HTTPS connections are not enforced by Ilmomasiina.\n'
+    + 'For security reasons, please set ENFORCE_HTTPS true or configure your load balancer or reverse proxy to'
+    + 'forward only HTTPS connections to Ilmomasiina.',
   );
 }
 

--- a/packages/ilmomasiina-backend/src/config.ts
+++ b/packages/ilmomasiina-backend/src/config.ts
@@ -1,8 +1,13 @@
+import path from 'path';
+
 const config = {
   nodeEnv: process.env.NODE_ENV || 'development',
   debugDbLogging: process.env.DEBUG_DB_LOGGING === 'true',
 
   port: process.env.PORT || 3000,
+
+  frontedFilesPath: process.env.FRONTEND_FILES_PATH
+    || path.dirname(require.resolve('@tietokilta/ilmomasiina-frontend/build/index.html')),
 
   dockerCompose: process.env.DOCKER_COMPOSE === 'true',
 

--- a/packages/ilmomasiina-backend/src/models/index.ts
+++ b/packages/ilmomasiina-backend/src/models/index.ts
@@ -23,7 +23,6 @@ export default function setupDatabase(this: IlmoApplication) {
   const {
     clearDbUrl,
     dbDialect, dbHost, dbDatabase, dbUser, dbPassword,
-    dockerCompose,
   } = config;
 
   let sequelize: Sequelize;
@@ -37,7 +36,7 @@ export default function setupDatabase(this: IlmoApplication) {
       dbUser!,
       dbPassword,
       {
-        host: dockerCompose ? 'db' : dbHost!,
+        host: dbHost!,
         dialect: dbDialect as Dialect,
         logging: config.debugDbLogging,
       },

--- a/packages/ilmomasiina-frontend/package.json
+++ b/packages/ilmomasiina-frontend/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "clean": "rimraf build",
-    "start": "node scripts/start.js",
+    "start:dev": "node scripts/start.js",
     "test": "node scripts/test.js --watchAll=false",
     "test:dev": "node scripts/test.js"
   },

--- a/packages/ilmomasiina-frontend/package.json
+++ b/packages/ilmomasiina-frontend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "clean": "rimraf build",
+    "start": "node scripts/start.js",
     "start:dev": "node scripts/start.js",
     "test": "node scripts/test.js --watchAll=false",
     "test:dev": "node scripts/test.js"

--- a/packages/ilmomasiina-models/package.json
+++ b/packages/ilmomasiina-models/package.json
@@ -5,5 +5,8 @@
     "type": "git",
     "url": "git+https://github.com/Tietokilta/ilmomasiina.git"
   },
+  "scripts": {
+    "build": "tsc --build"
+  },
   "license": "MIT"
 }

--- a/packages/ilmomasiina-models/tsconfig.json
+++ b/packages/ilmomasiina-models/tsconfig.json
@@ -13,7 +13,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "module": "ESNext",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
Updated the container setup.

Closes #26.

## Changes
- Changed to use PostgreSQL instead of MySQL
- Added a way to disable HTTPS enforcement by the ilmomasiina backend using the env variable `ENFORCE_HTTPS`:
  - Ideally this should be done by the proxy and not by the application as the application when the application is not responsible for HTTPS encryption. Backend still defaults to HTTPS enforcement.
- Updated dockerfiles:
  - `Dockerfile` for the production container
  - `Dockerfile.dev` for the local development container
- Updated docker compose scripts:
  - Updated `docker-compose.yml`: defines the container setup for development environment
  - Created `docker-compose.prod.yml`: an example of the deployment
- Bootstraps lerna automatically when running `npm install` (a post-install hook)
- Updated readme