### PR TITLE
Add iCalendar export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,3 +80,5 @@ BRANDING_FOOTER_HOME_LINK=https://athene.fi
 # Email strings
 BRANDING_MAIL_FOOTER_TEXT=Rakkaudella, Tietskarijengi & Athene
 BRANDING_MAIL_FOOTER_LINK=ilmo.athene.fi
+# iCalendar exported calendar name
+BRANDING_ICAL_CALENDAR_NAME=Ilmomasiina

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -115,4 +115,9 @@ CREATE TABLE `auditlog` (
   `updatedAt` DATETIME NOT NULL,
   PRIMARY KEY (`id`)
 );
+
+-- add end date to events
+
+ALTER TABLE `event`
+ADD `endDate` DATETIME DEFAULT NULL AFTER `date`;
 ```

--- a/packages/ilmomasiina-backend/package.json
+++ b/packages/ilmomasiina-backend/package.json
@@ -62,6 +62,7 @@
     "express-sslify": "^1.2.0",
     "feathers-hooks-common": "^5.0.5",
     "feathers-sequelize": "^6.3.2",
+    "ics": "^2.35.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.33",

--- a/packages/ilmomasiina-backend/src/config.ts
+++ b/packages/ilmomasiina-backend/src/config.ts
@@ -30,6 +30,7 @@ const config = <const>{
   mailFrom: envString('MAIL_FROM'),
   brandingMailFooterText: envString('BRANDING_MAIL_FOOTER_TEXT'),
   brandingMailFooterLink: envString('BRANDING_MAIL_FOOTER_LINK'),
+  icalCalendarName: envString('BRANDING_ICAL_CALENDAR_NAME', 'Ilmomasiina'),
   mailUrlBase: envString('EMAIL_BASE_URL'),
   pathPrefix: envString('PATH_PREFIX', ''),
 

--- a/packages/ilmomasiina-backend/src/models/migrations/0002-add-event-endDate.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/0002-add-event-endDate.ts
@@ -1,0 +1,18 @@
+import { DataTypes, Sequelize } from 'sequelize';
+import { RunnableMigration } from 'umzug';
+
+const migration: RunnableMigration<Sequelize> = {
+  name: '0002-add-event-endDate',
+  async up({ context: sequelize }) {
+    const query = sequelize.getQueryInterface();
+    await query.addColumn(
+      'event',
+      'endDate',
+      {
+        type: DataTypes.DATE,
+      },
+    );
+  },
+};
+
+export default migration;

--- a/packages/ilmomasiina-backend/src/models/migrations/index.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/index.ts
@@ -3,10 +3,12 @@ import { RunnableMigration } from 'umzug';
 
 import _0000_initial from './0000-initial';
 import _0001_add_audit_logs from './0001-add-audit-logs';
+import _0002_add_event_endDate from './0002-add-event-endDate';
 
 const migrations: RunnableMigration<Sequelize>[] = [
   _0000_initial,
   _0001_add_audit_logs,
+  _0002_add_event_endDate,
 ];
 
 export default migrations;

--- a/packages/ilmomasiina-backend/src/services/admin/event/updateEvent.ts
+++ b/packages/ilmomasiina-backend/src/services/admin/event/updateEvent.ts
@@ -1,4 +1,4 @@
-import { NotFound } from '@feathersjs/errors';
+import { BadRequest, NotFound } from '@feathersjs/errors';
 import { Params } from '@feathersjs/feathers';
 import _ from 'lodash';
 import { Op, Transaction } from 'sequelize';
@@ -75,6 +75,12 @@ export default async (
       || deletedQuotas.length
     ) {
       throw new EditConflict(event.updatedAt, deletedQuotas, deletedQuestions);
+    }
+
+    // Check that endDate isn't unset if date is present
+    const newDate = data.date === undefined ? event.date : data.date;
+    if (newDate !== null && event.endDate !== null && data.endDate === null) {
+      throw new BadRequest('Events must have endDate after it has been set once with date');
     }
 
     // Update the Event

--- a/packages/ilmomasiina-backend/src/services/admin/event/updateEvent.ts
+++ b/packages/ilmomasiina-backend/src/services/admin/event/updateEvent.ts
@@ -1,4 +1,4 @@
-import { BadRequest, NotFound } from '@feathersjs/errors';
+import { NotFound } from '@feathersjs/errors';
 import { Params } from '@feathersjs/feathers';
 import _ from 'lodash';
 import { Op, Transaction } from 'sequelize';
@@ -75,12 +75,6 @@ export default async (
       || deletedQuotas.length
     ) {
       throw new EditConflict(event.updatedAt, deletedQuotas, deletedQuestions);
-    }
-
-    // Check that endDate isn't unset if date is present
-    const newDate = data.date === undefined ? event.date : data.date;
-    if (newDate !== null && event.endDate !== null && data.endDate === null) {
-      throw new BadRequest('Events must have endDate after it has been set once with date');
     }
 
     // Update the Event

--- a/packages/ilmomasiina-backend/src/services/ical/index.ts
+++ b/packages/ilmomasiina-backend/src/services/ical/index.ts
@@ -36,6 +36,7 @@ export const icalService: Partial<ServiceMethods<any>> = {
     });
 
     const { error, value } = createEvents(events.map((event) => ({
+      calName: config.icalCalendarName,
       uid: `${event.id}@${uidDomain}`,
       start: dateToArray(event.date!),
       startInputType: 'utc',

--- a/packages/ilmomasiina-backend/src/services/ical/index.ts
+++ b/packages/ilmomasiina-backend/src/services/ical/index.ts
@@ -1,0 +1,60 @@
+import { ServiceMethods } from '@feathersjs/feathers';
+import { createEvents, DateArray } from 'ics';
+import { Op } from 'sequelize';
+
+import config from '../../config';
+import { IlmoApplication } from '../../defs';
+import { Event } from '../../models/event';
+
+function dateToArray(date: Date) {
+  return [
+    date.getUTCFullYear(),
+    date.getUTCMonth() + 1,
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+  ] as DateArray;
+}
+
+const uidDomain = new URL(config.mailUrlBase ?? 'http://localhost').hostname;
+
+export const icalService: Partial<ServiceMethods<any>> = {
+  async find() {
+    const events = await Event.scope('user').findAll({
+      where: {
+        listed: true,
+        // only events, not signup-only
+        date: { [Op.ne]: null },
+        // ignore legacy events with no end date
+        endDate: { [Op.ne]: null },
+      },
+      order: [
+        ['date', 'ASC'],
+        ['registrationEndDate', 'ASC'],
+        ['title', 'ASC'],
+      ],
+    });
+
+    const { error, value } = createEvents(events.map((event) => ({
+      uid: `${event.id}@${uidDomain}`,
+      start: dateToArray(event.date!),
+      startInputType: 'utc',
+      end: dateToArray(new Date(event.endDate!)),
+      endInputType: 'utc',
+      title: event.title,
+      description: event.description || undefined, // TODO convert markdown
+      location: event.location || undefined,
+      categories: event.category ? [event.category] : undefined,
+      url: `${config.mailUrlBase}${config.pathPrefix}/event/${event.slug}`,
+    })));
+
+    if (error !== null) throw new Error(`Failed to generate iCalendar: ${error}`);
+    return value;
+  },
+};
+
+export default function setupIcalService(this: IlmoApplication) {
+  const app = this;
+
+  app.use('/api/ical', icalService);
+}

--- a/packages/ilmomasiina-backend/src/services/index.ts
+++ b/packages/ilmomasiina-backend/src/services/index.ts
@@ -9,6 +9,7 @@ import adminSlug, { adminSlugService } from './admin/slug';
 import auditLog, { AuditLogService } from './auditlog';
 import authentication from './authentication';
 import event, { eventService } from './event';
+import ical, { icalService } from './ical';
 import signup, { signupService } from './signup';
 import user, { UsersService } from './user';
 
@@ -22,6 +23,7 @@ export interface IlmoServices {
   '/api/admin/slug': WrapService<typeof adminSlugService>;
   '/api/auditlog': AuditLogService;
   '/api/authentication': AuthenticationService;
+  '/api/ical': WrapService<typeof icalService>;
   '/api/events': WrapService<typeof eventService>;
   '/api/signups': WrapService<typeof signupService>;
   '/api/users': UsersService;
@@ -37,6 +39,7 @@ export default function setupServices(this: IlmoApplication) {
   app.configure(adminSlug);
   app.configure(auditLog);
   app.configure(event);
+  app.configure(ical);
   app.configure(signup);
   app.configure(user);
 }

--- a/packages/ilmomasiina-frontend/src/modules/editor/actions.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/actions.ts
@@ -25,6 +25,7 @@ export const defaultEvent = (): EditorEvent => ({
   title: '',
   slug: '',
   date: undefined,
+  endDate: undefined,
   webpageUrl: '',
   facebookUrl: '',
   category: '',
@@ -153,6 +154,7 @@ export const serverEventToEditor = (event: AdminEvent.Details): EditorEvent => (
   ...event,
   eventType: eventType(event),
   date: event.date ? new Date(event.date) : undefined,
+  endDate: event.endDate ? new Date(event.endDate) : undefined,
   registrationStartDate: event.registrationStartDate ? new Date(event.registrationStartDate) : undefined,
   registrationEndDate: event.registrationEndDate ? new Date(event.registrationEndDate) : undefined,
   quotas: event.quotas.map((quota) => ({
@@ -170,6 +172,7 @@ export const serverEventToEditor = (event: AdminEvent.Details): EditorEvent => (
 const editorEventToServer = (form: EditorEvent): AdminEvent.Update.Body => ({
   ...form,
   date: form.eventType === EditorEventType.ONLY_SIGNUP ? null : form.date?.toISOString() ?? null,
+  endDate: form.eventType === EditorEventType.ONLY_SIGNUP ? null : form.endDate?.toISOString() ?? null,
   registrationStartDate:
     form.eventType === EditorEventType.ONLY_EVENT ? null : form.registrationStartDate?.toISOString() ?? null,
   registrationEndDate:

--- a/packages/ilmomasiina-frontend/src/modules/editor/types.ts
+++ b/packages/ilmomasiina-frontend/src/modules/editor/types.ts
@@ -33,11 +33,12 @@ export enum EditorEventType {
 
 /** Root form data type for event editor */
 export interface EditorEvent extends Omit<
-AdminEvent.Update.Body, 'quotas' | 'questions' | 'date' | 'registrationStartDate' | 'registrationEndDate'
+AdminEvent.Update.Body, 'quotas' | 'questions' | 'date' | 'endDate' | 'registrationStartDate' | 'registrationEndDate'
 > {
   eventType: EditorEventType;
 
   date: Date | undefined;
+  endDate: Date | undefined;
 
   questions: EditorQuestion[];
 

--- a/packages/ilmomasiina-frontend/src/routes/Editor/components/BasicDetailsTab.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/components/BasicDetailsTab.tsx
@@ -71,9 +71,6 @@ const BasicDetailsTab = () => {
     }
   }
 
-  // require endDate with date, but only if it's not an old event that doesn't have endDate set
-  const endDateRequired = !event || event.endDate !== null;
-
   return (
     <div>
       <FieldRow
@@ -130,11 +127,7 @@ const BasicDetailsTab = () => {
           as={DateTimePicker}
           selectsEnd
           startDate={date}
-          required={endDateRequired}
-          alternateError="* Loppuaika vaaditaan."
-          help={
-            endDateRequired ? undefined : 'Tapahtuma näkyy kalenteriviennissä vain, jos sille on asetettu loppuaika.'
-          }
+          help="Tapahtuma näkyy kalenteriviennissä vain, jos sille on asetettu loppuaika."
         />
       )}
       <FieldRow

--- a/packages/ilmomasiina-frontend/src/routes/Editor/components/BasicDetailsTab.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/components/BasicDetailsTab.tsx
@@ -24,7 +24,9 @@ const BasicDetailsTab = () => {
   } = useTypedSelector((state) => state.editor, shallowEqual);
 
   const {
-    values: { title, slug, eventType },
+    values: {
+      title, slug, eventType, date, endDate,
+    },
     touched: { slug: slugTouched },
     setFieldValue,
   } = useFormikContext<EditorEvent>();
@@ -69,6 +71,9 @@ const BasicDetailsTab = () => {
     }
   }
 
+  // require endDate with date, but only if it's not an old event that doesn't have endDate set
+  const endDateRequired = !event || event.endDate !== null;
+
   return (
     <div>
       <FieldRow
@@ -110,10 +115,26 @@ const BasicDetailsTab = () => {
       {eventType !== EditorEventType.ONLY_SIGNUP && (
         <FieldRow
           name="date"
-          label="Ajankohta"
+          label="Alkuaika"
           as={DateTimePicker}
+          selectsStart
+          endDate={endDate}
           required
-          alternateError="* Ajankohta vaaditaan."
+          alternateError="* Alkuaika vaaditaan."
+        />
+      )}
+      {eventType !== EditorEventType.ONLY_SIGNUP && (
+        <FieldRow
+          name="endDate"
+          label="Loppuaika"
+          as={DateTimePicker}
+          selectsEnd
+          startDate={date}
+          required={endDateRequired}
+          alternateError="* Loppuaika vaaditaan."
+          help={
+            endDateRequired ? undefined : 'Tapahtuma näkyy kalenteriviennissä vain, jos sille on asetettu loppuaika.'
+          }
         />
       )}
       <FieldRow

--- a/packages/ilmomasiina-frontend/src/routes/Editor/components/DateTimePicker.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/components/DateTimePicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentPropsWithoutRef } from 'react';
 
 import fi from 'date-fns/locale/fi';
 import { useField } from 'formik';
@@ -8,16 +8,25 @@ import 'react-datepicker/dist/react-datepicker.css';
 
 registerLocale('fi', fi);
 
-type Props = {
+type Props = Pick<
+ComponentPropsWithoutRef<typeof DatePicker>,
+'selectsStart' | 'selectsEnd' | 'startDate' | 'endDate'
+> & {
   name: string;
 };
 
-export default function DateTimePicker({ name }: Props) {
+export default function DateTimePicker({
+  name, selectsStart, selectsEnd, startDate, endDate,
+}: Props) {
   const [{ value, onBlur }, , { setValue }] = useField(name);
   return (
     <DatePicker
       name={name}
       selected={value}
+      startDate={selectsStart ? value : startDate}
+      endDate={selectsEnd ? value : endDate}
+      selectsStart={selectsStart}
+      selectsEnd={selectsEnd}
       showTimeSelect
       showWeekNumbers
       className="form-control"

--- a/packages/ilmomasiina-frontend/src/routes/SingleEvent/SingleEvent.scss
+++ b/packages/ilmomasiina-frontend/src/routes/SingleEvent/SingleEvent.scss
@@ -23,10 +23,6 @@
   }
 }
 
-.event-description {
-  white-space: pre-wrap;
-}
-
 .single-event--loading-container {
   display: flex;
   flex-direction: column;

--- a/packages/ilmomasiina-frontend/src/routes/SingleEvent/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/SingleEvent/index.tsx
@@ -91,9 +91,16 @@ const SingleEvent = ({ match }: Props) => {
             )}
             {event.date && (
               <p>
-                <strong>Ajankohta:</strong>
+                <strong>{event.endDate ? 'Alkaa:' : 'Ajankohta:'}</strong>
                 {' '}
                 {moment(event.date).format('D.M.Y [klo] HH:mm')}
+              </p>
+            )}
+            {event.endDate && (
+              <p>
+                <strong>Loppuu:</strong>
+                {' '}
+                {moment(event.endDate).format('D.M.Y [klo] HH:mm')}
               </p>
             )}
             {event.location && (

--- a/packages/ilmomasiina-frontend/src/styles/_widgets.scss
+++ b/packages/ilmomasiina-frontend/src/styles/_widgets.scss
@@ -22,3 +22,8 @@
 
   $components: ('Combobox'),
 );
+
+// Stop combobox input showing through datepicker
+.rw-combobox-input {
+  z-index: auto !important;
+}

--- a/packages/ilmomasiina-frontend/src/utils/eventState.ts
+++ b/packages/ilmomasiina-frontend/src/utils/eventState.ts
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { AdminEvent } from '@tietokilta/ilmomasiina-models/src/services/admin/events';
 
 // eslint-disable-next-line import/prefer-default-export
-export function isEventInPast(event: Pick<AdminEvent.List.Event, 'date' | 'registrationEndDate'>) {
-  const endDate = event.date ?? event.registrationEndDate;
+export function isEventInPast(event: Pick<AdminEvent.List.Event, 'date' | 'endDate' | 'registrationEndDate'>) {
+  const endDate = event.endDate ?? event.date ?? event.registrationEndDate;
   return moment().isAfter(moment(endDate!).add(7, 'days'));
 }

--- a/packages/ilmomasiina-models/src/models/event.ts
+++ b/packages/ilmomasiina-models/src/models/event.ts
@@ -3,6 +3,7 @@ export default interface EventAttributes {
   title: string;
   slug: string;
   date: Date | null;
+  endDate: Date | null;
   registrationStartDate: Date | null;
   registrationEndDate: Date | null;
   openQuotaSize: number;

--- a/packages/ilmomasiina-models/src/services/admin/events/create.ts
+++ b/packages/ilmomasiina-models/src/services/admin/events/create.ts
@@ -7,6 +7,7 @@ export const adminEventCreateEventAttrs = [
   'title',
   'slug',
   'date',
+  'endDate',
   'registrationStartDate',
   'registrationEndDate',
   'openQuotaSize',

--- a/packages/ilmomasiina-models/src/services/events/details.ts
+++ b/packages/ilmomasiina-models/src/services/events/details.ts
@@ -9,6 +9,7 @@ export const eventGetEventAttrs = [
   'title',
   'slug',
   'date',
+  'endDate',
   'registrationStartDate',
   'registrationEndDate',
   'openQuotaSize',

--- a/packages/ilmomasiina-models/src/services/events/list.ts
+++ b/packages/ilmomasiina-models/src/services/events/list.ts
@@ -6,6 +6,7 @@ export const eventListEventAttrs = [
   'slug',
   'title',
   'date',
+  'endDate',
   'registrationStartDate',
   'registrationEndDate',
   'openQuotaSize',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,7 @@ importers:
       express-sslify: ^1.2.0
       feathers-hooks-common: ^5.0.5
       feathers-sequelize: ^6.3.2
+      ics: ^2.35.0
       lodash: ^4.17.21
       moment: ^2.29.1
       moment-timezone: ^0.5.33
@@ -95,6 +96,7 @@ importers:
       express-sslify: 1.2.0
       feathers-hooks-common: 5.0.6
       feathers-sequelize: 6.3.3
+      ics: 2.35.0
       lodash: 4.17.21
       moment: 2.29.3
       moment-timezone: 0.5.34
@@ -3570,7 +3572,7 @@ packages:
   /axios/0.21.4_debug@4.3.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.9
+      follow-redirects: 1.14.9_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -6167,6 +6169,18 @@ packages:
       debug:
         optional: true
 
+  /follow-redirects/1.14.9_debug@4.3.4:
+    resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: false
+
   /fork-ts-checker-webpack-plugin/6.5.2_5veyye6pi7qkei7u6hzcbshk2m:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
@@ -6725,6 +6739,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+    dev: false
+
+  /ics/2.35.0:
+    resolution: {integrity: sha512-uxHoiu9VnE/1RUIWoUqn9GVswUzrejHFa5Gk20gGySw+2FO8xzgJe7GLFk+hzmevHViG/6zANLhjVY6kFWctKQ==}
+    dependencies:
+      nanoid: 3.3.3
+      yup: 0.32.11
     dev: false
 
   /icss-utils/5.1.0_postcss@8.4.12:
@@ -8688,6 +8709,10 @@ packages:
       lru-cache: 4.1.5
     dev: false
 
+  /nanoclone/0.2.1:
+    resolution: {integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==}
+    dev: false
+
   /nanoid/3.3.3:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -10303,6 +10328,10 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+    dev: false
+
+  /property-expr/2.0.5:
+    resolution: {integrity: sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==}
     dev: false
 
   /property-information/6.1.1:
@@ -12012,6 +12041,10 @@ packages:
     resolution: {integrity: sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg=}
     dev: false
 
+  /toposort/2.0.2:
+    resolution: {integrity: sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=}
+    dev: false
+
   /tough-cookie/4.0.0:
     resolution: {integrity: sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==}
     engines: {node: '>=6'}
@@ -12933,6 +12966,19 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: false
+
+  /yup/0.32.11:
+    resolution: {integrity: sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@babel/runtime': 7.17.9
+      '@types/lodash': 4.14.182
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      nanoclone: 0.2.1
+      property-expr: 2.0.5
+      toposort: 2.0.2
     dev: false
 
   /zwitch/2.0.2:


### PR DESCRIPTION
Closes #20.

This PR adds an iCalendar export to Ilmomasiina, accessible at `/api/ical`. This can be imported into most calendar applications.