### PR TITLE
Feature/89 renew session token

### DIFF
--- a/packages/ilmomasiina-backend/src/routes/authentication/adminLogin.ts
+++ b/packages/ilmomasiina-backend/src/routes/authentication/adminLogin.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { HttpError, Unauthorized } from 'http-errors';
 
-import type { AdminLoginBody, AdminLoginResponse } from '@tietokilta/ilmomasiina-models';
+import type { AdminLoginBody, AdminLoginResponse, AdminRenewLoginBody } from '@tietokilta/ilmomasiina-models';
 import AdminAuthSession, { AdminTokenData } from '../../authentication/adminAuthSession';
 import AdminPasswordAuth from '../../authentication/adminPasswordAuth';
 import { User } from '../../models/user';
@@ -34,7 +34,7 @@ export function adminLogin(session: AdminAuthSession) {
 
 export function renewAdminToken(session: AdminAuthSession) {
   return async (
-    request: FastifyRequest<{ Body: AdminLoginBody }>,
+    request: FastifyRequest<{ Body: AdminRenewLoginBody }>,
     reply: FastifyReply,
   ): Promise<AdminLoginResponse | void> => {
     // Verify existing token

--- a/packages/ilmomasiina-backend/src/routes/authentication/adminLogin.ts
+++ b/packages/ilmomasiina-backend/src/routes/authentication/adminLogin.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { HttpError, Unauthorized } from 'http-errors';
 
-import type { AdminLoginBody, AdminLoginResponse, AdminRenewLoginBody } from '@tietokilta/ilmomasiina-models';
+import type { AdminLoginBody, AdminLoginResponse } from '@tietokilta/ilmomasiina-models';
 import AdminAuthSession, { AdminTokenData } from '../../authentication/adminAuthSession';
 import AdminPasswordAuth from '../../authentication/adminPasswordAuth';
 import { User } from '../../models/user';
@@ -34,7 +34,7 @@ export function adminLogin(session: AdminAuthSession) {
 
 export function renewAdminToken(session: AdminAuthSession) {
   return async (
-    request: FastifyRequest<{ Body: AdminRenewLoginBody }>,
+    request: FastifyRequest,
     reply: FastifyReply,
   ): Promise<AdminLoginResponse | void> => {
     // Verify existing token

--- a/packages/ilmomasiina-backend/src/routes/index.ts
+++ b/packages/ilmomasiina-backend/src/routes/index.ts
@@ -323,8 +323,6 @@ async function setupPublicRoutes(
     adminLogin(opts.adminSession),
   );
 
-  // an API endpoint for session token renewal as variant of adminLoginSchema
-
   server.post(
     '/authentication/renew',
     {
@@ -337,6 +335,7 @@ async function setupPublicRoutes(
     },
     renewAdminToken(opts.adminSession),
   );
+
   // Public routes for events
 
   server.get<{ Querystring: schema.EventListQuery }>(

--- a/packages/ilmomasiina-backend/src/routes/index.ts
+++ b/packages/ilmomasiina-backend/src/routes/index.ts
@@ -325,11 +325,10 @@ async function setupPublicRoutes(
 
   // an API endpoint for session token renewal as variant of adminLoginSchema
 
-  server.post<{ Body: schema.AdminRenewLoginBody }>(
+  server.post(
     '/authentication/renew',
     {
       schema: {
-        body: schema.adminRenewTokenBody,
         response: {
           ...errorResponses,
           201: schema.adminLoginResponse,

--- a/packages/ilmomasiina-backend/src/routes/index.ts
+++ b/packages/ilmomasiina-backend/src/routes/index.ts
@@ -17,7 +17,7 @@ import deleteUser from './admin/users/deleteUser';
 import inviteUser from './admin/users/inviteUser';
 import listUsers from './admin/users/listUsers';
 import resetPassword from './admin/users/resetPassword';
-import { adminLogin, requireAdmin } from './authentication/adminLogin';
+import { adminLogin, renewAdminToken, requireAdmin } from './authentication/adminLogin';
 import { getEventDetailsForAdmin, getEventDetailsForUser } from './events/getEventDetails';
 import { getEventsListForAdmin, getEventsListForUser } from './events/getEventsList';
 import { sendICalFeed } from './ical';
@@ -323,8 +323,21 @@ async function setupPublicRoutes(
     adminLogin(opts.adminSession),
   );
 
-  // TODO: Add an API endpoint for session token renewal as variant of adminLoginSchema
+  // an API endpoint for session token renewal as variant of adminLoginSchema
 
+  server.post<{ Body: schema.AdminRenewLoginBody }>(
+    '/authentication/renew',
+    {
+      schema: {
+        body: schema.adminRenewTokenBody,
+        response: {
+          ...errorResponses,
+          201: schema.adminLoginResponse,
+        },
+      },
+    },
+    renewAdminToken(opts.adminSession),
+  );
   // Public routes for events
 
   server.get<{ Querystring: schema.EventListQuery }>(

--- a/packages/ilmomasiina-components/src/api.ts
+++ b/packages/ilmomasiina-components/src/api.ts
@@ -39,7 +39,7 @@ export function configureApi(url: string) {
   apiUrl = url;
 }
 
-export default async function apiFetch<T = any>(uri: string, {
+export default async function apiFetch<T = unknown>(uri: string, {
   method = 'GET', body, headers, signal,
 }: FetchOptions = {}) {
   const allHeaders = {

--- a/packages/ilmomasiina-components/src/api.ts
+++ b/packages/ilmomasiina-components/src/api.ts
@@ -4,7 +4,6 @@ export interface FetchOptions {
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   body?: any;
   headers?: Record<string, string>;
-  accessToken?: string;
   signal?: AbortSignal;
 }
 
@@ -40,15 +39,12 @@ export function configureApi(url: string) {
   apiUrl = url;
 }
 
-export default async function apiFetch(uri: string, {
-  method = 'GET', body, headers, accessToken, signal,
+export default async function apiFetch<T = any>(uri: string, {
+  method = 'GET', body, headers, signal,
 }: FetchOptions = {}) {
   const allHeaders = {
     ...headers || {},
   };
-  if (accessToken) {
-    allHeaders.Authorization = accessToken;
-  }
   if (body !== undefined) {
     allHeaders['Content-Type'] = 'application/json; charset=utf-8';
   }
@@ -68,10 +64,10 @@ export default async function apiFetch(uri: string, {
   }
   // 204 No Content
   if (response.status === 204) {
-    return null;
+    return null as T;
   }
   // just in case, convert JSON parse errors for 2xx responses to ApiError
   return response.json().catch((err) => {
     throw new ApiError(0, err);
-  });
+  }) as Promise<T>;
 }

--- a/packages/ilmomasiina-components/src/contexts/auth.ts
+++ b/packages/ilmomasiina-components/src/contexts/auth.ts
@@ -1,7 +1,6 @@
 import { createContext } from 'react';
 
 export interface AuthState {
-  accessToken?: string;
   loggedIn: boolean;
 }
 

--- a/packages/ilmomasiina-frontend/src/api.ts
+++ b/packages/ilmomasiina-frontend/src/api.ts
@@ -7,7 +7,7 @@ import type { DispatchAction } from './store/types';
 interface AdminApiFetchOptions extends FetchOptions {
   accessToken?: AccessToken;
 }
-
+const RENEW_LOGIN_THRESHOLD = 5 * 60 * 1000;
 /** Wrapper for apiFetch that checks for Unauthenticated responses and dispatches a loginExpired
  * action if necessary.
  */
@@ -18,7 +18,7 @@ export default async function adminApiFetch<T = any>(uri: string, opts: AdminApi
     if (!accessToken) {
       throw new ApiError(401, { isUnauthenticated: true });
     }
-    if (!(accessToken.expiresAt < Date.now() - 4 * 60 * 1000)) {
+    if (!(accessToken.expiresAt < Date.now() - RENEW_LOGIN_THRESHOLD)) {
       await dispatch(renewLogin(accessToken.token));
     }
     return await apiFetch<T>(uri, { ...opts, headers: { ...opts.headers, Authorization: accessToken.token } });

--- a/packages/ilmomasiina-frontend/src/api.ts
+++ b/packages/ilmomasiina-frontend/src/api.ts
@@ -1,14 +1,23 @@
 import { ApiError, apiFetch, FetchOptions } from '@tietokilta/ilmomasiina-components';
 import { ErrorCode } from '@tietokilta/ilmomasiina-models';
 import { loginExpired } from './modules/auth/actions';
+import { AccessToken } from './modules/auth/types';
 import type { DispatchAction } from './store/types';
+
+interface AdminApiFetchOptions extends FetchOptions {
+  accessToken?: AccessToken;
+}
 
 /** Wrapper for apiFetch that checks for Unauthenticated responses and dispatches a loginExpired
  * action if necessary.
  */
-export default async function adminApiFetch(uri: string, opts: FetchOptions, dispatch: DispatchAction) {
+export default async function adminApiFetch(uri: string, opts: AdminApiFetchOptions, dispatch: DispatchAction) {
   try {
-    return await apiFetch(uri, opts);
+    const { accessToken } = opts;
+    if (!accessToken) {
+      throw new ApiError(401, { isUnauthenticated: true });
+    }
+    return await apiFetch(uri, { ...opts, headers: { ...opts.headers, Authorization: accessToken.token } });
   } catch (err) {
     if (err instanceof ApiError && err.code === ErrorCode.BAD_SESSION) {
       dispatch(loginExpired());

--- a/packages/ilmomasiina-frontend/src/api.ts
+++ b/packages/ilmomasiina-frontend/src/api.ts
@@ -12,7 +12,7 @@ const RENEW_LOGIN_THRESHOLD = 5 * 60 * 1000;
  * action if necessary.
  */
 // eslint-disable-next-line max-len
-export default async function adminApiFetch<T = any>(uri: string, opts: AdminApiFetchOptions, dispatch: DispatchAction) {
+export default async function adminApiFetch<T = unknown>(uri: string, opts: AdminApiFetchOptions, dispatch: DispatchAction) {
   try {
     const { accessToken } = opts;
     if (!accessToken) {

--- a/packages/ilmomasiina-frontend/src/containers/requireAuth.tsx
+++ b/packages/ilmomasiina-frontend/src/containers/requireAuth.tsx
@@ -9,11 +9,11 @@ export default function requireAuth<P extends {}>(WrappedComponent: ComponentTyp
   const RequireAuth = (props: P) => {
     const dispatch = useTypedDispatch();
 
-    const { accessToken, accessTokenExpires } = useTypedSelector(
+    const { accessToken } = useTypedSelector(
       (state) => state.auth,
     );
 
-    const expired = accessTokenExpires && new Date(accessTokenExpires) < new Date();
+    const expired = accessToken && accessToken.expiresAt < Date.now();
     const needLogin = expired || !accessToken;
 
     useEffect(() => {

--- a/packages/ilmomasiina-frontend/src/modules/adminEvents/actions.ts
+++ b/packages/ilmomasiina-frontend/src/modules/adminEvents/actions.ts
@@ -29,7 +29,8 @@ export type AdminEventsActions =
 
 export const getAdminEvents = () => async (dispatch: DispatchAction, getState: GetState) => {
   try {
-    const response = await adminApiFetch('admin/events', { accessToken: getState().auth.accessToken }, dispatch);
+    const { accessToken } = getState().auth;
+    const response = await adminApiFetch('admin/events', { accessToken }, dispatch);
     dispatch(eventsLoaded(response as AdminEventListResponse));
   } catch (e) {
     dispatch(eventsLoadFailed(e as ApiError));

--- a/packages/ilmomasiina-frontend/src/modules/adminEvents/actions.ts
+++ b/packages/ilmomasiina-frontend/src/modules/adminEvents/actions.ts
@@ -28,9 +28,8 @@ export type AdminEventsActions =
   | ReturnType<typeof resetState>;
 
 export const getAdminEvents = () => async (dispatch: DispatchAction, getState: GetState) => {
-  const { accessToken } = getState().auth;
   try {
-    const response = await adminApiFetch('admin/events', { accessToken }, dispatch);
+    const response = await adminApiFetch('admin/events', { accessToken: getState().auth.accessToken }, dispatch);
     dispatch(eventsLoaded(response as AdminEventListResponse));
   } catch (e) {
     dispatch(eventsLoadFailed(e as ApiError));

--- a/packages/ilmomasiina-frontend/src/modules/auth/actionTypes.ts
+++ b/packages/ilmomasiina-frontend/src/modules/auth/actionTypes.ts
@@ -1,2 +1,3 @@
 export const LOGIN_SUCCEEDED = 'auth/LOGIN_SUCCEEDED';
 export const RESET = 'auth/RESET';
+export const RENEWING_TOKEN = 'auth/RENEWING_TOKEN';

--- a/packages/ilmomasiina-frontend/src/modules/auth/actionTypes.ts
+++ b/packages/ilmomasiina-frontend/src/modules/auth/actionTypes.ts
@@ -1,3 +1,2 @@
 export const LOGIN_SUCCEEDED = 'auth/LOGIN_SUCCEEDED';
 export const RESET = 'auth/RESET';
-export const RENEWING_TOKEN = 'auth/RENEWING_TOKEN';

--- a/packages/ilmomasiina-frontend/src/modules/auth/actions.ts
+++ b/packages/ilmomasiina-frontend/src/modules/auth/actions.ts
@@ -78,3 +78,23 @@ export const loginExpired = () => (dispatch: DispatchAction) => {
   loginToast('error', i18n.t('auth.loginExpired'), 10000);
   dispatch(redirectToLogin());
 };
+
+export const renewLogin = (accessToken: string) => async (dispatch: DispatchAction) => {
+  if (accessToken) {
+    const sessionResponse = await apiFetch<AdminLoginResponse>('authentication/renew', {
+      method: 'POST',
+      body: {
+        accessToken,
+      },
+      headers: {
+        Authorization: accessToken,
+      },
+    });
+    if (sessionResponse) {
+      dispatch(loginSucceeded(sessionResponse));
+      return true;
+    }
+  }
+  dispatch(loginExpired());
+  return false;
+};

--- a/packages/ilmomasiina-frontend/src/modules/auth/actions.ts
+++ b/packages/ilmomasiina-frontend/src/modules/auth/actions.ts
@@ -36,13 +36,13 @@ const loginToast = (type: 'success' | 'error', text: string, autoClose: number) 
 };
 
 export const login = (email: string, password: string) => async (dispatch: DispatchAction) => {
-  const sessionResponse = await apiFetch('authentication', {
+  const sessionResponse = await apiFetch<AdminLoginResponse>('authentication', {
     method: 'POST',
     body: {
       email,
       password,
     },
-  }) as AdminLoginResponse;
+  });
   dispatch(loginSucceeded(sessionResponse));
   dispatch(push(appPaths.adminEventsList));
   loginToast('success', i18n.t('auth.loginSuccess'), 2000);

--- a/packages/ilmomasiina-frontend/src/modules/auth/reducer.ts
+++ b/packages/ilmomasiina-frontend/src/modules/auth/reducer.ts
@@ -1,29 +1,26 @@
-import moment, { Moment } from 'moment';
-
 import { LOGIN_SUCCEEDED, RESET } from './actionTypes';
 import type { AuthActions, AuthState } from './types';
 
 const initialState: AuthState = {
   accessToken: undefined,
-  accessTokenExpires: undefined,
   loggedIn: false,
 };
 
-function getTokenExpiry(jwt: string): Moment {
+function getTokenExpiry(jwt: string): number {
   const parts = jwt.split('.');
 
   try {
     const payload = JSON.parse(window.atob(parts[1]));
 
     if (payload.exp) {
-      return moment.unix(payload.exp);
+      return payload.exp * 1000;
     }
   } catch {
     // eslint-disable-next-line no-console
     console.error('Invalid jwt token received!');
   }
 
-  return moment();
+  return 0;
 }
 
 export default function reducer(
@@ -35,8 +32,10 @@ export default function reducer(
       return initialState;
     case LOGIN_SUCCEEDED:
       return {
-        accessToken: action.payload.accessToken,
-        accessTokenExpires: getTokenExpiry(action.payload.accessToken).toISOString(),
+        accessToken: {
+          token: action.payload.accessToken,
+          expiresAt: getTokenExpiry(action.payload.accessToken),
+        },
         loggedIn: true,
       };
     default:

--- a/packages/ilmomasiina-frontend/src/modules/auth/types.ts
+++ b/packages/ilmomasiina-frontend/src/modules/auth/types.ts
@@ -1,6 +1,9 @@
+export interface AccessToken {
+  token: string;
+  expiresAt: number; // Unix timestamp
+}
 export interface AuthState {
-  accessToken?: string;
-  accessTokenExpires?: string;
+  accessToken?: AccessToken;
   loggedIn: boolean;
 }
 

--- a/packages/ilmomasiina-models/src/schema/login/index.ts
+++ b/packages/ilmomasiina-models/src/schema/login/index.ts
@@ -9,11 +9,6 @@ export const adminLoginBody = Type.Object({
     description: 'Plaintext password.',
   }),
 });
-export const adminRenewTokenBody = Type.Object({
-  accessToken: Type.String({
-    description: 'JWT access token. Used in `Authorization` header to authorize requests.',
-  }),
-});
 /** Response schema for a successful login. */
 export const adminLoginResponse = Type.Object({
   accessToken: Type.String({
@@ -23,7 +18,5 @@ export const adminLoginResponse = Type.Object({
 
 /** Request body for login. */
 export type AdminLoginBody = Static<typeof adminLoginBody>;
-/** Request body for renewLogin */
-export type AdminRenewLoginBody = Static<typeof adminRenewTokenBody>;
 /** Response schema for a successful login. */
 export type AdminLoginResponse = Static<typeof adminLoginResponse>;

--- a/packages/ilmomasiina-models/src/schema/login/index.ts
+++ b/packages/ilmomasiina-models/src/schema/login/index.ts
@@ -9,7 +9,11 @@ export const adminLoginBody = Type.Object({
     description: 'Plaintext password.',
   }),
 });
-
+export const adminRenewTokenBody = Type.Object({
+  accessToken: Type.String({
+    description: 'JWT access token. Used in `Authorization` header to authorize requests.',
+  }),
+});
 /** Response schema for a successful login. */
 export const adminLoginResponse = Type.Object({
   accessToken: Type.String({
@@ -19,5 +23,7 @@ export const adminLoginResponse = Type.Object({
 
 /** Request body for login. */
 export type AdminLoginBody = Static<typeof adminLoginBody>;
+/** Request body for renewLogin */
+export type AdminRenewLoginBody = Static<typeof adminRenewTokenBody>;
 /** Response schema for a successful login. */
 export type AdminLoginResponse = Static<typeof adminLoginResponse>;


### PR DESCRIPTION
Refactored auth typing in frontend and had it refresh the token using the already existing but not yet mapped to a route endpoint. Functionality is the following:
If the admin has logged and tries to reach an admin endpoint, the code checks the expiry time of the access token. If access token is expiring in less than 4 minutes, request a new access token from the endpoint.


Closes #89 