### PR TITLE
Use optional chaining

### DIFF
--- a/packages/ilmomasiina-components/src/config/index.ts
+++ b/packages/ilmomasiina-components/src/config/index.ts
@@ -14,10 +14,14 @@ export interface IlmoConfig {
 
 let configuredTimezone = 'Europe/Helsinki';
 
-export function configure(config: IlmoConfig) {
-  if (config.api !== undefined) configureApi(config.api);
-  if (config.router !== undefined) configureRouter(config.router);
-  if (config.timezone !== undefined) configuredTimezone = config.timezone;
+export function configure({
+  api = '/api',
+  router,
+  timezone = 'Europe/Helsinki',
+}: IlmoConfig) {
+  configureApi(api);
+  configureRouter?.(router);
+  configuredTimezone = timezone;
 }
 
 export function timezone() {


### PR DESCRIPTION
If you're using a version of TypeScript that supports optional chaining, you can simplify the conditional checks further.