### PR TITLE
Optimize event data fetching

### DIFF
--- a/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
+++ b/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { NotFound } from 'http-errors';
-import { Order } from 'sequelize';
+import { Op, Order } from 'sequelize';
 
 import type {
   AdminEventPathParams, AdminEventResponse, EventID, EventSlug, UserEventPathParams, UserEventResponse,
@@ -20,47 +20,24 @@ import { Quota } from '../../models/quota';
 import { Signup } from '../../models/signup';
 import { stringifyDates } from '../utils';
 
-const eventOrdering: Order = [
-  [Question, 'order', 'ASC'],
-  [Quota, 'order', 'ASC'],
-  [Quota, Signup, 'createdAt', 'ASC'],
+const answerOrdering: Order = [
+  ['order', 'ASC'],
+  [Signup, 'createdAt', 'ASC'],
 ];
 
 export async function eventDetailsForUser(
   eventSlug: EventSlug,
 ): Promise<UserEventResponse> {
+  // First query general event information
   const event = await Event.scope('user').findOne({
     where: { slug: eventSlug },
     attributes: [...eventGetEventAttrs],
     include: [
-      // First include all questions (also non-public for the form)
       {
         model: Question,
         attributes: [...eventGetQuestionAttrs],
       },
-      // Include quotas..
-      {
-        model: Quota,
-        attributes: [...eventGetQuotaAttrs],
-        // ... and signups of quotas
-        include: [
-          {
-            model: Signup.scope('active'),
-            attributes: [...eventGetSignupAttrs, 'confirmedAt'],
-            required: false,
-            // ... and answers of signups
-            include: [
-              {
-                model: Answer,
-                attributes: [...eventGetAnswerAttrs],
-                required: false,
-              },
-            ],
-          },
-        ],
-      },
     ],
-    order: eventOrdering,
   });
 
   if (!event) {
@@ -68,19 +45,41 @@ export async function eventDetailsForUser(
     throw new NotFound('No event found with id');
   }
 
+  // Only return answers to public questions
+  const publicQuestions = event.questions!
+    .filter((question) => question.public)
+    .map((question) => question.id);
+
+  // Query all quotas for the event
+  const quotas = await Quota.findAll({
+    where: { eventId: event.id },
+    attributes: [...eventGetQuotaAttrs],
+    include: [
+      // Include all signups for the quota
+      {
+        model: Signup.scope('active'),
+        attributes: [...eventGetSignupAttrs, 'confirmedAt'],
+        required: false,
+        include: [
+          // ... and public answers of signups
+          {
+            model: Answer,
+            attributes: [...eventGetAnswerAttrs],
+            required: false,
+            where: { questionId: { [Op.in]: publicQuestions } },
+          },
+        ],
+      },
+    ],
+    order: answerOrdering,
+  });
+
   const questions = event.questions!.map((question) => ({
     ...question.get({ plain: true }),
     // Split answer options into array
     // TODO: Splitting by semicolon might cause problems - requires better solution
     options: question.options ? question.options.split(';') : null,
   }));
-
-  // Only return answers to public questions
-  const publicQuestions = new Set(
-    event.questions!
-      .filter((question) => question.public)
-      .map((question) => question.id),
-  );
 
   // Dynamic extra fields
   let registrationClosed = true;
@@ -99,7 +98,7 @@ export async function eventDetailsForUser(
     ...stringifyDates(event.get({ plain: true })),
     questions,
 
-    quotas: event.quotas!.map((quota) => ({
+    quotas: quotas!.map((quota) => ({
       ...quota.get({ plain: true }),
       signups: event.signupsPublic // Hide all signups from non-admins if answers are not public
       // When signups are public:
@@ -108,8 +107,7 @@ export async function eventDetailsForUser(
           // Hide name if necessary
           firstName: event.nameQuestion && signup.namePublic ? signup.firstName : null,
           lastName: event.nameQuestion && signup.namePublic ? signup.lastName : null,
-          // Hide answers of non-public questions
-          answers: signup.answers!.filter((answer) => publicQuestions.has(answer.questionId)),
+          answers: signup.answers!,
           status: signup.status,
           confirmed: signup.confirmedAt !== null,
         }))

--- a/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
+++ b/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
@@ -99,7 +99,7 @@ export async function eventDetailsForUser(
     ...stringifyDates(event.get({ plain: true })),
     questions,
 
-    quotas: quotas!.map((quota) => ({
+    quotas: quotas.map((quota) => ({
       ...quota.get({ plain: true }),
       signups: event.signupsPublic // Hide all signups from non-admins if answers are not public
         // When signups are public:

--- a/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
+++ b/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
@@ -36,6 +36,7 @@ export async function eventDetailsForUser(
       {
         model: Question,
         attributes: [...eventGetQuestionAttrs],
+        order: ['order', 'ASC'],
       },
     ],
   });
@@ -47,7 +48,7 @@ export async function eventDetailsForUser(
 
   // Only return answers to public questions
   const publicQuestions = event.questions!
-    .filter((question) => question.public)
+  .filter((question) => question.public)
     .map((question) => question.id);
 
   // Query all quotas for the event
@@ -101,18 +102,18 @@ export async function eventDetailsForUser(
     quotas: quotas!.map((quota) => ({
       ...quota.get({ plain: true }),
       signups: event.signupsPublic // Hide all signups from non-admins if answers are not public
-      // When signups are public:
+        // When signups are public:
         ? quota.signups!.map((signup) => ({
-          ...stringifyDates(signup.get({ plain: true })),
-          // Hide name if necessary
-          firstName: event.nameQuestion && signup.namePublic ? signup.firstName : null,
-          lastName: event.nameQuestion && signup.namePublic ? signup.lastName : null,
-          answers: signup.answers!,
-          status: signup.status,
-          confirmed: signup.confirmedAt !== null,
-        }))
-      // When signups are not public:
-        : [],
+            ...stringifyDates(signup.get({ plain: true })),
+            // Hide name if necessary
+            firstName: event.nameQuestion && signup.namePublic ? signup.firstName : null,
+            lastName: event.nameQuestion && signup.namePublic ? signup.lastName : null,
+            answers: signup.answers!,
+            status: signup.status,
+            confirmed: signup.confirmedAt !== null,
+          }))
+        // When signups are not public:
+          : [],
       signupCount: quota.signups!.length,
     })),
 


### PR DESCRIPTION
Implemented this change in our system and observed a speedup of ~10x when fetching event information. Improvement will probably not be as dramatic for modern hardware with good networking, but some similar change could probably be useful either way if you're interested. This is a quick and dirty optimization, the queries could be optimized further but this was enough to make the system usable for us.


The JOIN statements generated by sequelize copies over the data from each selected column to every row, leading to a database query with a massive amount of redundant data. Example: For 100 signups with 5 answers each, the full event description is returned 500 times. By separating these queries the data passed between the database and the backend is cut down significantly.

Additionally, this separation of event and quota querying means that only answers to public questions need to be queried, further reducing the size of the returned data greatly.