### PR TITLE
Stop splitting strings by magic semicolons

### DIFF
--- a/packages/ilmomasiina-backend/src/app.ts
+++ b/packages/ilmomasiina-backend/src/app.ts
@@ -22,6 +22,11 @@ export default async function initApp(): Promise<FastifyInstance> {
   const server = fastify({
     trustProxy: config.isAzure || config.trustProxy, // Get IPs from X-Forwarded-For
     logger: true, // Enable logger
+    ajv: {
+      customOptions: {
+        coerceTypes: false, // Disable type coercion - we don't need it, and it breaks stuff like anyOf
+      },
+    },
   });
 
   // Register fastify-sensible (https://github.com/fastify/fastify-sensible)

--- a/packages/ilmomasiina-backend/src/mail/signupConfirmation.ts
+++ b/packages/ilmomasiina-backend/src/mail/signupConfirmation.ts
@@ -28,7 +28,7 @@ export default async function sendSignupConfirmationMail(signup: Signup) {
     .filter(([, answer]) => answer)
     .map(([question, answer]) => ({
       label: question.question,
-      answer: answer!.answer,
+      answer: Array.isArray(answer!.answer) ? answer!.answer.join(', ') : answer!.answer,
     }));
 
   const edited = answers.some((answer) => answer.createdAt.getTime() !== answer.updatedAt.getTime());

--- a/packages/ilmomasiina-backend/src/models/answer.ts
+++ b/packages/ilmomasiina-backend/src/models/answer.ts
@@ -12,7 +12,7 @@ export interface AnswerCreationAttributes extends Optional<AnswerAttributes, 'id
 
 export class Answer extends Model<AnswerAttributes, AnswerCreationAttributes> implements AnswerAttributes {
   public id!: string;
-  public answer!: string;
+  public answer!: string | string[];
 
   public questionId!: Question['id'];
   public question?: Question;
@@ -48,6 +48,15 @@ export default function setupAnswerModel(sequelize: Sequelize) {
     answer: {
       type: DataTypes.STRING,
       allowNull: false,
+      // TODO: Once we upgrade to Sequelize v7, try migrating this to custom datatypes again.
+      get(): string | string[] {
+        const json = this.getDataValue('answer');
+        return json === null ? null : JSON.parse(json as unknown as string);
+      },
+      set(val: string[] | null) {
+        const json = val === null ? null : JSON.stringify(val);
+        this.setDataValue('answer', json as unknown as (string | string[]));
+      },
     },
   }, {
     sequelize,

--- a/packages/ilmomasiina-backend/src/models/migrations/0000-initial.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/0000-initial.ts
@@ -1,12 +1,13 @@
-import { DataTypes, Sequelize } from 'sequelize';
-import { RunnableMigration } from 'umzug';
+import { DataTypes } from 'sequelize';
+
+import { defineMigration } from './util';
 
 // Constant from ../randomId
 const RANDOM_ID_LENGTH = 12;
 
-const migration: RunnableMigration<Sequelize> = {
+export default defineMigration({
   name: '0000-initial',
-  async up({ context: sequelize }) {
+  async up({ context: { sequelize, transaction } }) {
     const query = sequelize.getQueryInterface();
     await query.createTable(
       'event',
@@ -97,6 +98,7 @@ const migration: RunnableMigration<Sequelize> = {
           type: DataTypes.DATE,
         },
       },
+      { transaction },
     );
     await query.createTable(
       'quota',
@@ -138,6 +140,7 @@ const migration: RunnableMigration<Sequelize> = {
           type: DataTypes.DATE,
         },
       },
+      { transaction },
     );
     await query.createTable(
       'signup',
@@ -190,6 +193,7 @@ const migration: RunnableMigration<Sequelize> = {
           type: DataTypes.DATE,
         },
       },
+      { transaction },
     );
     await query.createTable(
       'question',
@@ -246,6 +250,7 @@ const migration: RunnableMigration<Sequelize> = {
           type: DataTypes.DATE,
         },
       },
+      { transaction },
     );
     await query.createTable(
       'answer',
@@ -291,6 +296,7 @@ const migration: RunnableMigration<Sequelize> = {
           type: DataTypes.DATE,
         },
       },
+      { transaction },
     );
     await query.createTable(
       'user',
@@ -318,8 +324,7 @@ const migration: RunnableMigration<Sequelize> = {
           allowNull: false,
         },
       },
+      { transaction },
     );
   },
-};
-
-export default migration;
+});

--- a/packages/ilmomasiina-backend/src/models/migrations/0001-add-audit-logs.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/0001-add-audit-logs.ts
@@ -1,12 +1,13 @@
-import { DataTypes, Sequelize } from 'sequelize';
-import { RunnableMigration } from 'umzug';
+import { DataTypes } from 'sequelize';
+
+import { defineMigration } from './util';
 
 // Constant from ../randomId
 const RANDOM_ID_LENGTH = 12;
 
-const migration: RunnableMigration<Sequelize> = {
+export default defineMigration({
   name: '0001-add-audit-logs',
-  async up({ context: sequelize }) {
+  async up({ context: { sequelize, transaction } }) {
     const query = sequelize.getQueryInterface();
     await query.createTable(
       'auditlog',
@@ -57,8 +58,7 @@ const migration: RunnableMigration<Sequelize> = {
           allowNull: false,
         },
       },
+      { transaction },
     );
   },
-};
-
-export default migration;
+});

--- a/packages/ilmomasiina-backend/src/models/migrations/0002-add-event-endDate.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/0002-add-event-endDate.ts
@@ -1,9 +1,10 @@
-import { DataTypes, Sequelize } from 'sequelize';
-import { RunnableMigration } from 'umzug';
+import { DataTypes } from 'sequelize';
 
-const migration: RunnableMigration<Sequelize> = {
+import { defineMigration } from './util';
+
+export default defineMigration({
   name: '0002-add-event-endDate',
-  async up({ context: sequelize }) {
+  async up({ context: { sequelize, transaction } }) {
     const query = sequelize.getQueryInterface();
     await query.addColumn(
       'event',
@@ -11,8 +12,7 @@ const migration: RunnableMigration<Sequelize> = {
       {
         type: DataTypes.DATE,
       },
+      { transaction },
     );
   },
-};
-
-export default migration;
+});

--- a/packages/ilmomasiina-backend/src/models/migrations/0003-add-signup-language.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/0003-add-signup-language.ts
@@ -1,9 +1,10 @@
-import { DataTypes, Sequelize } from 'sequelize';
-import { RunnableMigration } from 'umzug';
+import { DataTypes } from 'sequelize';
 
-const migration: RunnableMigration<Sequelize> = {
+import { defineMigration } from './util';
+
+export default defineMigration({
   name: '0003-add-signup-language',
-  async up({ context: sequelize }) {
+  async up({ context: { sequelize, transaction } }) {
     const query = sequelize.getQueryInterface();
     await query.addColumn(
       'signup',
@@ -12,8 +13,7 @@ const migration: RunnableMigration<Sequelize> = {
         type: DataTypes.STRING(8),
         allowNull: true,
       },
+      { transaction },
     );
   },
-};
-
-export default migration;
+});

--- a/packages/ilmomasiina-backend/src/models/migrations/0004-answers-to-json.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/0004-answers-to-json.ts
@@ -4,6 +4,7 @@ import { defineMigration } from './util';
 
 type RawQuestion = {
   id: string;
+  type: string;
   options: string;
 };
 
@@ -21,11 +22,14 @@ export default defineMigration({
     const query = sequelize.getQueryInterface();
     // Convert question options to JSON
     const questions = await sequelize.query<RawQuestion>(
-      'SELECT `id`, `options` FROM `question`',
+      'SELECT `id`, `type`, `options` FROM `question`',
       { type: QueryTypes.SELECT, transaction },
     );
     for (const row of questions) {
-      const optionsJson = row.options ? JSON.stringify(row.options.split(';')) : null;
+      let optionsJson = null;
+      if (row.type === 'checkbox' || row.type === 'select') {
+        optionsJson = row.options ? JSON.stringify(row.options.split(';')) : JSON.stringify(['']);
+      }
       await query.bulkUpdate(
         'question',
         { options: optionsJson },

--- a/packages/ilmomasiina-backend/src/models/migrations/0004-answers-to-json.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/0004-answers-to-json.ts
@@ -1,0 +1,57 @@
+import { QueryTypes } from 'sequelize';
+
+import { defineMigration } from './util';
+
+type RawQuestion = {
+  id: string;
+  options: string;
+};
+
+type RawAnswer = {
+  id: string;
+  answer: string;
+  type: string;
+};
+
+/* eslint-disable no-await-in-loop */
+
+export default defineMigration({
+  name: '0004-answers-to-json',
+  async up({ context: { sequelize, transaction } }) {
+    const query = sequelize.getQueryInterface();
+    // Convert question options to JSON
+    const questions = await sequelize.query<RawQuestion>(
+      'SELECT `id`, `options` FROM `question`',
+      { type: QueryTypes.SELECT, transaction },
+    );
+    for (const row of questions) {
+      const optionsJson = row.options ? JSON.stringify(row.options.split(';')) : null;
+      await query.bulkUpdate(
+        'question',
+        { options: optionsJson },
+        { id: row.id },
+        { transaction },
+      );
+    }
+    // Convert answers to JSON
+    const answers = await sequelize.query<RawAnswer>(
+      'SELECT `answer`.`id`, `answer`.`answer`, `question`.`type` '
+      + 'FROM `answer` '
+      + 'LEFT JOIN `question` ON `answer`.`questionId` = `question`.`id`',
+      { type: QueryTypes.SELECT, transaction },
+    );
+    for (const row of answers) {
+      // Non-checkbox question -> "entire answer"
+      // Non-empty answer to checkbox question -> ["ans1", "ans2"]
+      // Empty answer to checkbox question -> []
+      const answer = row.type === 'checkbox' ? row.answer.split(';').filter(Boolean) : row.answer;
+      const answerJson = JSON.stringify(answer);
+      await query.bulkUpdate(
+        'answer',
+        { answer: answerJson },
+        { id: row.id },
+        { transaction },
+      );
+    }
+  },
+});

--- a/packages/ilmomasiina-backend/src/models/migrations/0004-answers-to-json.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/0004-answers-to-json.ts
@@ -20,9 +20,11 @@ export default defineMigration({
   name: '0004-answers-to-json',
   async up({ context: { sequelize, transaction } }) {
     const query = sequelize.getQueryInterface();
+    // Handle different quoting for Postgres & MySQL
+    const q = ([name]: TemplateStringsArray) => query.quoteIdentifiers(name);
     // Convert question options to JSON
     const questions = await sequelize.query<RawQuestion>(
-      'SELECT `id`, `type`, `options` FROM `question`',
+      `SELECT ${q`id`}, ${q`type`}, ${q`options`} FROM ${q`question`}`,
       { type: QueryTypes.SELECT, transaction },
     );
     for (const row of questions) {
@@ -39,9 +41,9 @@ export default defineMigration({
     }
     // Convert answers to JSON
     const answers = await sequelize.query<RawAnswer>(
-      'SELECT `answer`.`id`, `answer`.`answer`, `question`.`type` '
-      + 'FROM `answer` '
-      + 'LEFT JOIN `question` ON `answer`.`questionId` = `question`.`id`',
+      `SELECT ${q`answer.id`}, ${q`answer.answer`}, ${q`question.type`} `
+      + `FROM ${q`answer`} `
+      + `LEFT JOIN ${q`question`} ON ${q`answer.questionId`} = ${q`question.id`}`,
       { type: QueryTypes.SELECT, transaction },
     );
     for (const row of answers) {

--- a/packages/ilmomasiina-backend/src/models/migrations/index.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/index.ts
@@ -5,12 +5,14 @@ import _0000_initial from './0000-initial';
 import _0001_add_audit_logs from './0001-add-audit-logs';
 import _0002_add_event_endDate from './0002-add-event-endDate';
 import _0003_add_signup_language from './0003-add-signup-language';
+import _0004_answers_to_json from './0004-answers-to-json';
 
 const migrations: RunnableMigration<Sequelize>[] = [
   _0000_initial,
   _0001_add_audit_logs,
   _0002_add_event_endDate,
   _0003_add_signup_language,
+  _0004_answers_to_json,
 ];
 
 export default migrations;

--- a/packages/ilmomasiina-backend/src/models/migrations/util.ts
+++ b/packages/ilmomasiina-backend/src/models/migrations/util.ts
@@ -1,0 +1,25 @@
+import { Sequelize, Transaction } from 'sequelize';
+import { RunnableMigration } from 'umzug';
+
+export type MigrationContext = {
+  sequelize: Sequelize;
+  transaction: Transaction;
+};
+
+export function defineMigration(migration: RunnableMigration<MigrationContext>): RunnableMigration<Sequelize> {
+  return {
+    ...migration,
+    up: ({ context: sequelize, ...params }) => (
+      sequelize.transaction((transaction) => migration.up({
+        ...params,
+        context: { sequelize, transaction },
+      }))
+    ),
+    down: migration.down && (({ context: sequelize, ...params }) => (
+      sequelize.transaction((transaction) => migration.down!({
+        ...params,
+        context: { sequelize, transaction },
+      }))
+    )),
+  };
+}

--- a/packages/ilmomasiina-backend/src/models/question.ts
+++ b/packages/ilmomasiina-backend/src/models/question.ts
@@ -19,7 +19,7 @@ export class Question extends Model<QuestionAttributes, QuestionCreationAttribut
   public order!: number;
   public question!: string;
   public type!: QuestionType;
-  public options!: string | null;
+  public options!: string[] | null;
   public required!: boolean;
   public public!: boolean;
 
@@ -74,6 +74,15 @@ export default function setupQuestionModel(sequelize: Sequelize) {
     options: {
       type: DataTypes.STRING,
       allowNull: true,
+      // TODO: Once we upgrade to Sequelize v7, try migrating this to custom datatypes again.
+      get(): string[] {
+        const json = this.getDataValue('options');
+        return json === null ? null : JSON.parse(json as unknown as string);
+      },
+      set(val: string[] | null) {
+        const json = val === null ? null : JSON.stringify(val);
+        this.setDataValue('options', json as unknown as string[]);
+      },
     },
     required: {
       type: DataTypes.BOOLEAN,

--- a/packages/ilmomasiina-backend/src/routes/admin/events/createEvent.ts
+++ b/packages/ilmomasiina-backend/src/routes/admin/events/createEvent.ts
@@ -22,7 +22,7 @@ export default async function createEvent(
         questions: request.body.questions ? request.body.questions.map((q, order) => ({
           ...q,
           order,
-          options: (q.options && q.options.length) ? q.options.join(';') : null,
+          options: q.options?.length ? q : null,
         })) : [],
         // add order to quotas
         quotas: request.body.quotas ? request.body.quotas.map((q, order) => ({ ...q, order })) : [],

--- a/packages/ilmomasiina-backend/src/routes/admin/events/updateEvent.ts
+++ b/packages/ilmomasiina-backend/src/routes/admin/events/updateEvent.ts
@@ -106,16 +106,10 @@ export default async function updateEvent(
         };
         // Update if an id was provided
         if (question.existing) {
-          await question.existing.update({
-            ...questionAttribs,
-            // TODO: Splitting by semicolon might cause problems - requires better solution
-            options: questionAttribs.options ? questionAttribs.options.join(';') : null,
-          }, { transaction });
+          await question.existing.update(questionAttribs, { transaction });
         } else {
           await Question.create({
             ...questionAttribs,
-            // TODO: Splitting by semicolon might cause problems - requires better solution
-            options: questionAttribs.options ? questionAttribs.options.join(';') : null,
             eventId: event.id,
           }, { transaction });
         }

--- a/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
+++ b/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
@@ -68,13 +68,6 @@ export async function eventDetailsForUser(
     throw new NotFound('No event found with id');
   }
 
-  const questions = event.questions!.map((question) => ({
-    ...question.get({ plain: true }),
-    // Split answer options into array
-    // TODO: Splitting by semicolon might cause problems - requires better solution
-    options: question.options ? question.options.split(';') : null,
-  }));
-
   // Only return answers to public questions
   const publicQuestions = new Set(
     event.questions!
@@ -97,8 +90,7 @@ export async function eventDetailsForUser(
 
   return {
     ...stringifyDates(event.get({ plain: true })),
-    questions,
-
+    questions: event.questions!.map((question) => question.get({ plain: true })),
     quotas: event.quotas!.map((quota) => ({
       ...quota.get({ plain: true }),
       signups: event.signupsPublic // Hide all signups from non-admins if answers are not public
@@ -175,12 +167,7 @@ export async function eventDetailsForAdmin(
   // Admins get a simple result with many columns
   return stringifyDates({
     ...event.get({ plain: true }),
-    questions: event.questions!.map((question) => ({
-      ...question.get({ plain: true }),
-      // Split answer options into array
-      // TODO: Splitting by semicolon might cause problems - requires better solution
-      options: question.options ? question.options.split(';') : null,
-    })),
+    questions: event.questions!.map((question) => question.get({ plain: true })),
     updatedAt: event.updatedAt,
     quotas: event.quotas!.map((quota) => ({
       ...quota.get({ plain: true }),

--- a/packages/ilmomasiina-backend/src/routes/signups/getSignupForEdit.ts
+++ b/packages/ilmomasiina-backend/src/routes/signups/getSignupForEdit.ts
@@ -54,11 +54,7 @@ export default async function getSignupForEdit(
     },
     event: {
       ...stringifyDates(event.get({ plain: true })),
-      questions: event.questions!.map((question) => ({
-        ...question.get({ plain: true }),
-        // Split answer options into array
-        options: question.options ? question.options.split(';') : null,
-      })),
+      questions: event.questions!.map((question) => question.get({ plain: true })),
     },
   };
 

--- a/packages/ilmomasiina-backend/src/routes/signups/updateSignup.ts
+++ b/packages/ilmomasiina-backend/src/routes/signups/updateSignup.ts
@@ -73,16 +73,33 @@ export default async function updateSignup(
 
     // Check that all questions are answered with a valid answer
     const newAnswers = questions.map((question) => {
-      const answer = request.body.answers
+      const emptyAnswer = question.type === 'checkbox' ? [] : '';
+      let answer = request.body.answers
         ?.find((a) => a.questionId === question.id)
-        ?.answer
-        || '';
+        ?.answer;
 
-      if (!answer) {
+      if (!answer || !answer.length) {
+        // Normalize empty answers
         if (question.required) {
           throw new BadRequest(`Missing answer for question ${question.question}`);
         }
+        answer = emptyAnswer;
+      } else if (question.type === 'checkbox') {
+        // Ensure checkbox answers are arrays
+        if (!Array.isArray(answer)) {
+          throw new BadRequest(`Invalid answer to question ${question.question}`);
+        }
+        // Check that all checkbox answers are valid
+        answer.forEach((option) => {
+          if (!question.options!.includes(option)) {
+            throw new BadRequest(`Invalid answer to question ${question.question}`);
+          }
+        });
       } else {
+        // Don't allow arrays for non-checkbox questions
+        if (typeof answer !== 'string') {
+          throw new BadRequest(`Invalid answer to question ${question.question}`);
+        }
         switch (question.type) {
           case 'text':
           case 'textarea':
@@ -95,23 +112,9 @@ export default async function updateSignup(
             break;
           case 'select': {
             // Check that the select answer is valid
-            const options = question.options!.split(';');
-
-            if (!options.includes(answer)) {
+            if (!question.options!.includes(answer)) {
               throw new BadRequest(`Invalid answer to question ${question.question}`);
             }
-            break;
-          }
-          case 'checkbox': {
-            // Check that all checkbox answers are valid
-            const options = question.options!.split(';');
-            const answers = answer.split(';');
-
-            answers.forEach((option) => {
-              if (!options.includes(option)) {
-                throw new BadRequest(`Invalid answer to question ${question.question}`);
-              }
-            });
             break;
           }
           default:

--- a/packages/ilmomasiina-backend/src/routes/signups/updateSignup.ts
+++ b/packages/ilmomasiina-backend/src/routes/signups/updateSignup.ts
@@ -73,17 +73,18 @@ export default async function updateSignup(
 
     // Check that all questions are answered with a valid answer
     const newAnswers = questions.map((question) => {
-      const emptyAnswer = question.type === 'checkbox' ? [] : '';
+      // Fetch the answer to this question from the request body
       let answer = request.body.answers
         ?.find((a) => a.questionId === question.id)
         ?.answer;
 
       if (!answer || !answer.length) {
-        // Normalize empty answers
+        // Disallow empty answers to required questions
         if (question.required) {
           throw new BadRequest(`Missing answer for question ${question.question}`);
         }
-        answer = emptyAnswer;
+        // Normalize empty answers to "" or [], depending on question type
+        answer = question.type === 'checkbox' ? [] : '';
       } else if (question.type === 'checkbox') {
         // Ensure checkbox answers are arrays
         if (!Array.isArray(answer)) {

--- a/packages/ilmomasiina-components/src/routes/SingleEvent/components/SignupListRow.tsx
+++ b/packages/ilmomasiina-components/src/routes/SingleEvent/components/SignupListRow.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 import { timezone } from '../../../config';
 import { useSingleEventContext } from '../../../modules/singleEvent';
-import { SignupWithQuota } from '../../../utils/signupUtils';
+import { SignupWithQuota, stringifyAnswer } from '../../../utils/signupUtils';
 
 type Props = {
   index: number;
@@ -50,7 +50,7 @@ const SignupListRow = ({ showQuota, signup, index }: Props) => {
       )}
       {filter(questions, 'public').map((question) => (
         <td key={question.id}>
-          {find(answers, { questionId: question.id })?.answer || ''}
+          {stringifyAnswer(find(answers, { questionId: question.id })?.answer || '')}
         </td>
       ))}
       {showQuota && (

--- a/packages/ilmomasiina-components/src/utils/signupUtils.ts
+++ b/packages/ilmomasiina-components/src/utils/signupUtils.ts
@@ -101,7 +101,7 @@ export function getSignupsByQuota(event: AnyEventSchema): QuotaSignups[] {
 }
 
 function getAnswersFromSignup(event: AdminEventResponse, signup: AnySignupSchema) {
-  const answers: Record<QuestionID, string> = {};
+  const answers: Record<QuestionID, string | string[]> = {};
 
   event.questions.forEach((question) => {
     const answer = find(signup.answers, { questionId: question.id });
@@ -116,7 +116,7 @@ export type FormattedSignup = {
   firstName: string | null;
   lastName: string | null;
   email: string | null;
-  answers: Record<QuestionID, string>;
+  answers: Record<QuestionID, string | string[]>;
   quota: string;
   createdAt: string;
   confirmed: boolean;
@@ -148,6 +148,11 @@ export function getSignupsForAdminList(event: AdminEventResponse): FormattedSign
   });
 }
 
+/** Formats an answer for display. */
+export function stringifyAnswer(answer: string | string[] | undefined) {
+  return Array.isArray(answer) ? answer.join(', ') : (answer ?? '');
+}
+
 /** Converts an array of signup rows from `getSignupsForAdminList` to a an array of CSV cells. */
 export function convertSignupsToCSV(event: AdminEventResponse, signups: FormattedSignup[]): string[][] {
   return [
@@ -164,7 +169,7 @@ export function convertSignupsToCSV(event: AdminEventResponse, signups: Formatte
       ...(event.nameQuestion ? [signup.firstName || '', signup.lastName || ''] : []),
       ...(event.emailQuestion ? [signup.email || ''] : []),
       signup.quota,
-      ...event.questions.map((question) => signup.answers[question.id] || ''),
+      ...event.questions.map((question) => stringifyAnswer(signup.answers[question.id])),
       signup.createdAt,
     ]),
   ];

--- a/packages/ilmomasiina-frontend/src/routes/Editor/components/SignupsTab.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/components/SignupsTab.tsx
@@ -4,7 +4,9 @@ import { Button } from 'react-bootstrap';
 import { CSVLink } from 'react-csv';
 import { useTranslation } from 'react-i18next';
 
-import { convertSignupsToCSV, getSignupsForAdminList } from '@tietokilta/ilmomasiina-components/dist/utils/signupUtils';
+import {
+  convertSignupsToCSV, getSignupsForAdminList, stringifyAnswer,
+} from '@tietokilta/ilmomasiina-components/dist/utils/signupUtils';
 import { deleteSignup, getEvent } from '../../../modules/editor/actions';
 import { useTypedDispatch, useTypedSelector } from '../../../store/reducers';
 
@@ -61,7 +63,9 @@ const SignupsTab = () => {
               {event.emailQuestion && <td key="email">{signup.email}</td>}
               <td key="quota">{signup.quota}</td>
               {event.questions.map((question) => (
-                <td key={question.id}>{signup.answers[question.id]}</td>
+                <td key={question.id}>
+                  {stringifyAnswer(signup.answers[question.id])}
+                </td>
               ))}
               <td key="timestamp">{signup.createdAt}</td>
               <td key="delete">

--- a/packages/ilmomasiina-models/src/models/answer.ts
+++ b/packages/ilmomasiina-models/src/models/answer.ts
@@ -3,7 +3,7 @@ import SignupAttributes from './signup';
 
 export default interface AnswerAttributes {
   id: string;
-  answer: string;
+  answer: string | string[];
   questionId: QuestionAttributes['id'];
   signupId: SignupAttributes['id'];
 }

--- a/packages/ilmomasiina-models/src/models/question.ts
+++ b/packages/ilmomasiina-models/src/models/question.ts
@@ -6,7 +6,7 @@ export default interface QuestionAttributes {
   order: number;
   question: string;
   type: QuestionType;
-  options: string | null;
+  options: string[] | null;
   required: boolean;
   public: boolean;
   eventId: EventAttributes['id'];

--- a/packages/ilmomasiina-models/src/schema/signup/attributes.ts
+++ b/packages/ilmomasiina-models/src/schema/signup/attributes.ts
@@ -25,9 +25,13 @@ export const editToken = Type.String({
 /** Answer to a single signup question */
 export const signupAnswer = Type.Object({
   questionId: questionID,
-  answer: Type.String({
-    description: 'Answer to the question.',
-  }),
+  answer: Type.Union(
+    [
+      Type.String(),
+      Type.Array(Type.String()),
+    ],
+    { description: 'Answer to the question.' },
+  ),
 });
 
 /** Editable attributes of a signup. */


### PR DESCRIPTION
Fixes #92. The app now natively handles answer options and multiple checkbox answers as arrays, instead of splitting strings by semicolon.

The migration for this does a best effort translation of the data in the DB. I don't think we can do much better. Importantly, the previous implementation made no difference between "selected empty option" and "selected no options" &ndash; the migration guesses the latter.

Along the way, I added transactions to the migration system and disabled Ajv type coercion. (Coercion was breaking `anyOf` unions, and I really don't think we'll need it anywhere. I guess we'll see...)