### PR TITLE
fix open quotas bugging UI like hell when there are many events

### DIFF
--- a/packages/ilmomasiina-components/src/modules/events/index.tsx
+++ b/packages/ilmomasiina-components/src/modules/events/index.tsx
@@ -11,7 +11,7 @@ export type EventListProps = {
 };
 
 type State = {
-  events: UserEventListResponse;
+  events?: UserEventListResponse;
   pending: boolean;
   error?: ApiError;
 };
@@ -26,7 +26,7 @@ export function useEventListState({ category }: EventListProps = {}) {
   }, [category]);
 
   return useShallowMemo<State>({
-    events: fetchEvents.result ?? [],
+    events: fetchEvents.result,
     pending: fetchEvents.pending,
     error: fetchEvents.error as ApiError | undefined,
   });

--- a/packages/ilmomasiina-components/src/modules/events/index.tsx
+++ b/packages/ilmomasiina-components/src/modules/events/index.tsx
@@ -11,7 +11,7 @@ export type EventListProps = {
 };
 
 type State = {
-  events?: UserEventListResponse;
+  events: UserEventListResponse;
   pending: boolean;
   error?: ApiError;
 };
@@ -26,7 +26,7 @@ export function useEventListState({ category }: EventListProps = {}) {
   }, [category]);
 
   return useShallowMemo<State>({
-    events: fetchEvents.result,
+    events: fetchEvents.result ?? [],
     pending: fetchEvents.pending,
     error: fetchEvents.error as ApiError | undefined,
   });

--- a/packages/ilmomasiina-components/src/routes/Events/index.tsx
+++ b/packages/ilmomasiina-components/src/routes/Events/index.tsx
@@ -56,7 +56,9 @@ const EventListView = () => {
   const { events, error, pending } = useEventListContext();
   const { t } = useTranslation();
   const paths = usePaths();
-  const tableRows = useMemo(() => eventsToRows(events).filter((row) => row.type !== 'waitlist'), [events]);
+
+  const tableRows = useMemo(() => eventsToRows(events ?? []).filter((row) => row.type !== 'waitlist'), [events]);
+
   // If initial setup is needed and is possible on this frontend, redirect to that page.
   if (error && error.code === ErrorCode.INITIAL_SETUP_NEEDED && paths.hasAdmin) {
     return <Navigate to={paths.adminInitialSetup} />;

--- a/packages/ilmomasiina-components/src/utils/eventListUtils.ts
+++ b/packages/ilmomasiina-components/src/utils/eventListUtils.ts
@@ -16,8 +16,8 @@ export interface EventTableOptions {
 }
 
 export type EventRow = {
-  isEvent: true;
   id: EventID,
+  type: 'event';
   slug: EventSlug,
   title: string,
   date: Moment | null,
@@ -28,8 +28,8 @@ export type EventRow = {
   totalQuotaSize: number | null;
 };
 export type QuotaRow = {
-  isEvent: false;
-  id: QuotaID | typeof OPENQUOTA | typeof WAITLIST;
+  type: 'quota' | 'openquota' | 'waitlist';
+  id: QuotaID;
   title?: string;
   signupCount: number;
   quotaSize: number | null;
@@ -45,7 +45,7 @@ export function eventToRows(event: UserEventListItem, { compact }: EventTableOpt
 
   // Event row
   const rows: TableRow[] = [{
-    isEvent: true,
+    type: 'event',
     id,
     signupState: state,
     slug,
@@ -63,7 +63,7 @@ export function eventToRows(event: UserEventListItem, { compact }: EventTableOpt
   // Multiple quotas go on their own rows
   if (quotas.length > 1) {
     quotas.forEach((quota) => rows.push({
-      isEvent: false,
+      type: 'quota',
       id: quota.id,
       title: quota.title,
       signupCount: quota.size ? Math.min(quota.signupCount, quota.size) : quota.signupCount,
@@ -76,8 +76,8 @@ export function eventToRows(event: UserEventListItem, { compact }: EventTableOpt
   // Open quota
   if (openQuotaSize > 0) {
     rows.push({
-      isEvent: false,
-      id: OPENQUOTA,
+      type: 'openquota',
+      id: event.id + OPENQUOTA,
       signupCount: Math.min(overflow, openQuotaSize),
       quotaSize: openQuotaSize,
     });
@@ -86,8 +86,8 @@ export function eventToRows(event: UserEventListItem, { compact }: EventTableOpt
   // Queue/waitlist
   if (overflow > openQuotaSize) {
     rows.push({
-      isEvent: false,
-      id: WAITLIST,
+      type: 'waitlist',
+      id: event.id + WAITLIST,
       signupCount: overflow - openQuotaSize,
       quotaSize: null,
     });

--- a/packages/ilmomasiina-components/src/utils/eventListUtils.ts
+++ b/packages/ilmomasiina-components/src/utils/eventListUtils.ts
@@ -6,9 +6,6 @@ import type {
   EventID, EventSlug, QuotaID, UserEventListItem, UserEventListResponse,
 } from '@tietokilta/ilmomasiina-models';
 import { signupState, SignupStateInfo } from './signupStateText';
-import { OPENQUOTA, WAITLIST } from './signupUtils';
-
-export { OPENQUOTA, WAITLIST };
 
 export interface EventTableOptions {
   /** If true, quotas are not placed on separate rows. */
@@ -77,7 +74,7 @@ export function eventToRows(event: UserEventListItem, { compact }: EventTableOpt
   if (openQuotaSize > 0) {
     rows.push({
       type: 'openquota',
-      id: event.id + OPENQUOTA,
+      id: `${event.id} openquota`,
       signupCount: Math.min(overflow, openQuotaSize),
       quotaSize: openQuotaSize,
     });
@@ -87,7 +84,7 @@ export function eventToRows(event: UserEventListItem, { compact }: EventTableOpt
   if (overflow > openQuotaSize) {
     rows.push({
       type: 'waitlist',
-      id: event.id + WAITLIST,
+      id: `${event.id} waitlist`,
       signupCount: overflow - openQuotaSize,
       quotaSize: null,
     });

--- a/packages/ilmomasiina-components/src/utils/signupUtils.ts
+++ b/packages/ilmomasiina-components/src/utils/signupUtils.ts
@@ -11,9 +11,9 @@ import { SignupStatus } from '@tietokilta/ilmomasiina-models';
 import { timezone } from '../config';
 
 /** Placeholder quota ID for the open quota. */
-export const OPENQUOTA = '\x00open';
+export const OPENQUOTA = '\x00open' as const;
 /** Placeholder quota ID for the queue. */
-export const WAITLIST = '\x00waitlist';
+export const WAITLIST = '\x00waitlist' as const;
 
 export type AnyEventSchema = AdminEventResponse | UserEventResponse;
 export type AnySignupSchema = AdminSignupSchema | PublicSignupSchema;
@@ -76,7 +76,7 @@ export function getSignupsByQuota(event: AnyEventSchema): QuotaSignups[] {
   const openSignups = signups.filter((signup) => signup.status === 'in-open');
   // Open quota is shown if the event has one, or if signups have been assigned there nevertheless.
   const openQuota = openSignups.length > 0 || event.openQuotaSize > 0 ? [{
-    id: OPENQUOTA as typeof OPENQUOTA,
+    id: OPENQUOTA,
     title: 'Avoin kiintiö',
     size: event.openQuotaSize,
     signups: openSignups,
@@ -86,7 +86,7 @@ export function getSignupsByQuota(event: AnyEventSchema): QuotaSignups[] {
   const queueSignups = signups.filter((signup) => signup.status === 'in-queue');
   // Queue is shown if signups have been assigned there.
   const queue = queueSignups.length > 0 ? [{
-    id: WAITLIST as typeof WAITLIST,
+    id: WAITLIST,
     title: 'Jonossa',
     size: null,
     signups: queueSignups,


### PR DESCRIPTION
If there are lots of events (created 2000 for performance optimization testing), the site event list becomes quite wonky when switching between languages. This should fix that.
