### PR TITLE
remove stringifyDates, not needed as JSON serializer converts to ISO …

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint packages",
     "lint:fix": "npm run lint -- --fix",
     "typecheck": "pnpm run -r --workspace-concurrency=1 typecheck",
-    "test": "pnpm run -r test"
+    "test": "pnpm run -r test",
+    "test:backend": "pnpm run --filter ilmomasiina-backend test"
   },
   "repository": {
     "type": "git",

--- a/packages/ilmomasiina-backend/src/routes/admin/auditlog/getAuditLogs.ts
+++ b/packages/ilmomasiina-backend/src/routes/admin/auditlog/getAuditLogs.ts
@@ -4,7 +4,7 @@ import { Op, WhereOptions } from 'sequelize';
 import type { AuditLogResponse, AuditLoqQuery } from '@tietokilta/ilmomasiina-models';
 import { auditLoqQuery } from '@tietokilta/ilmomasiina-models';
 import { AuditLog } from '../../../models/auditlog';
-import { stringifyDates } from '../../utils';
+import { StringifyApi } from '../../utils';
 
 const MAX_LOGS = 100;
 
@@ -57,11 +57,12 @@ export default async function getAuditLogItems(
   });
 
   response.status(200);
-  return {
-    rows: logs.rows.map((r) => stringifyDates({
+  const res = {
+    rows: logs.rows.map((r) => ({
       ...r.get({ plain: true }),
       createdAt: r.createdAt,
     })),
     count: logs.count,
   };
+  return res as unknown as StringifyApi<typeof res>;
 }

--- a/packages/ilmomasiina-backend/src/routes/admin/events/createEvent.ts
+++ b/packages/ilmomasiina-backend/src/routes/admin/events/createEvent.ts
@@ -8,7 +8,7 @@ import { Event } from '../../../models/event';
 import { Question } from '../../../models/question';
 import { Quota } from '../../../models/quota';
 import { eventDetailsForAdmin } from '../../events/getEventDetails';
-import { stringifyDates, toDate } from '../../utils';
+import { toDate } from '../../utils';
 
 export default async function createEvent(
   request: FastifyRequest<{ Body: EventCreateBody }>,
@@ -55,5 +55,5 @@ export default async function createEvent(
   const eventDetails = await eventDetailsForAdmin(event.id);
 
   response.status(201);
-  return stringifyDates(eventDetails);
+  return eventDetails;
 }

--- a/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
+++ b/packages/ilmomasiina-backend/src/routes/events/getEventDetails.ts
@@ -18,7 +18,7 @@ import { Event } from '../../models/event';
 import { Question } from '../../models/question';
 import { Quota } from '../../models/quota';
 import { Signup } from '../../models/signup';
-import { stringifyDates } from '../utils';
+import { StringifyApi } from '../utils';
 
 export async function eventDetailsForUser(
   eventSlug: EventSlug,
@@ -87,15 +87,15 @@ export async function eventDetailsForUser(
     registrationClosed = now > endDate;
   }
 
-  return {
-    ...stringifyDates(event.get({ plain: true })),
+  const res = {
+    ...(event.get({ plain: true })),
     questions: event.questions!.map((question) => question.get({ plain: true })),
     quotas: quotas.map((quota) => ({
       ...quota.get({ plain: true }),
       signups: event.signupsPublic // Hide all signups from non-admins if answers are not public
         // When signups are public:
         ? quota.signups!.map((signup) => ({
-          ...stringifyDates(signup.get({ plain: true })),
+          ...(signup.get({ plain: true })),
           // Hide name if necessary
           firstName: event.nameQuestion && signup.namePublic ? signup.firstName : null,
           lastName: event.nameQuestion && signup.namePublic ? signup.lastName : null,
@@ -111,6 +111,7 @@ export async function eventDetailsForUser(
     millisTillOpening,
     registrationClosed,
   };
+  return res as unknown as StringifyApi<typeof res>;
 }
 
 export async function eventDetailsForAdmin(
@@ -165,7 +166,7 @@ export async function eventDetailsForAdmin(
   });
 
   // Admins get a simple result with many columns
-  return stringifyDates({
+  const res = {
     ...event.get({ plain: true }),
     questions: event.questions!.map((question) => question.get({ plain: true })),
     updatedAt: event.updatedAt,
@@ -179,7 +180,8 @@ export async function eventDetailsForAdmin(
       })),
       signupCount: quota.signups!.length,
     })),
-  });
+  };
+  return res as unknown as StringifyApi<typeof res>;
 }
 
 export async function getEventDetailsForUser(

--- a/packages/ilmomasiina-backend/src/routes/events/getEventsList.ts
+++ b/packages/ilmomasiina-backend/src/routes/events/getEventsList.ts
@@ -11,7 +11,7 @@ import { Quota } from '../../models/quota';
 import { Signup } from '../../models/signup';
 import { ascNullsFirst } from '../../models/util';
 import { InitialSetupNeeded, isInitialSetupDone } from '../admin/users/createInitialUser';
-import { stringifyDates } from '../utils';
+import { StringifyApi } from '../utils';
 
 function eventOrder(): Order {
   return [
@@ -60,7 +60,7 @@ export async function getEventsListForUser(
   });
 
   const res = events.map((event) => ({
-    ...stringifyDates(event.get({ plain: true })),
+    ...event.get({ plain: true }),
     quotas: event.quotas!.map((quota) => ({
       ...quota.get({ plain: true }),
       signupCount: Number(quota.signupCount),
@@ -68,7 +68,7 @@ export async function getEventsListForUser(
   }));
 
   reply.status(200);
-  return res;
+  return res as StringifyApi<typeof res>;
 }
 export async function getEventsListForAdmin(
   request: FastifyRequest<{ Querystring: EventListQuery }>,
@@ -103,7 +103,7 @@ export async function getEventsListForAdmin(
   });
 
   const res = events.map((event) => ({
-    ...stringifyDates(event.get({ plain: true })),
+    ...event.get({ plain: true }),
     quotas: event.quotas!.map((quota) => ({
       ...quota.get({ plain: true }),
       signupCount: Number(quota.signupCount!),
@@ -111,5 +111,5 @@ export async function getEventsListForAdmin(
   }));
 
   reply.status(200);
-  return res;
+  return res as StringifyApi<typeof res>;
 }

--- a/packages/ilmomasiina-backend/src/routes/signups/getSignupForEdit.ts
+++ b/packages/ilmomasiina-backend/src/routes/signups/getSignupForEdit.ts
@@ -6,7 +6,7 @@ import { Event } from '../../models/event';
 import { Question } from '../../models/question';
 import { Quota } from '../../models/quota';
 import { Signup } from '../../models/signup';
-import { stringifyDates } from '../utils';
+import { StringifyApi } from '../utils';
 import { NoSuchSignup } from './errors';
 
 /** Requires editTokenVerification */
@@ -46,19 +46,19 @@ export default async function getSignupForEdit(
 
   const response = {
     signup: {
-      ...stringifyDates(signup.get({ plain: true })),
+      ...signup.get({ plain: true }),
       confirmed: Boolean(signup.confirmedAt),
       status: signup.status,
       answers: signup.answers!,
       quota: signup.quota!,
     },
     event: {
-      ...stringifyDates(event.get({ plain: true })),
+      ...event.get({ plain: true }),
       questions: event.questions!.map((question) => question.get({ plain: true })),
     },
   };
 
   reply.status(200);
 
-  return response;
+  return response as unknown as StringifyApi<typeof response>;
 }

--- a/packages/ilmomasiina-backend/src/routes/utils.ts
+++ b/packages/ilmomasiina-backend/src/routes/utils.ts
@@ -1,4 +1,5 @@
 /** Converts given value to a Date if it is a string, and otherwise just passthroughs the input */
+// eslint-disable-next-line import/prefer-default-export
 export function toDate<T>(s: T): Date | Exclude<T, string> {
   return typeof s === 'string' ? new Date(s) : s as Exclude<T, string>;
 }
@@ -8,32 +9,13 @@ export type StringifyApi<T> = {
   [P in keyof T]: (
     // all arrays are stringified recursively
     T[P] extends (infer E)[] ? StringifyApi<E>[]
-      // Date | null --> string | null
-      // Date --> string
-      // (also matches "x: null", but that's an useless type anyway)
+    // Date | null --> string | null
+    // Date --> string
+    // (also matches "x: null", but that's an useless type anyway)
       : T[P] extends Date | null ? (null extends T[P] ? string | null : string)
-        // basic types: any subset of boolean | number | string | null --> itself
+      // basic types: any subset of boolean | number | string | null --> itself
         : T[P] extends boolean | number | string | null ? T[P]
-          // other types (essentially, objects) are stringified recursively
+        // other types (essentially, objects) are stringified recursively
           : StringifyApi<T[P]>
   );
 };
-
-/** Recursively converts all `Date` objects in the given object to strings. */
-export function stringifyDates<T>(obj: T): StringifyApi<T> {
-  if (typeof obj !== 'object' || obj === null) {
-    return obj as any;
-  }
-  if (Array.isArray(obj)) {
-    return obj.map(stringifyDates) as any;
-  }
-  return Object.fromEntries(Object.entries(obj).map(([key, val]) => {
-    if (val instanceof Date) {
-      return [key, val.toISOString()];
-    }
-    if (typeof val === 'object' && val !== null) {
-      return [key, stringifyDates(val)];
-    }
-    return [key, val];
-  })) as any;
-}


### PR DESCRIPTION
Removes `stringifyDate`-function and uses `StringifyApi` instead, no need to do conversions, when JSON serializer does it for you.