### PR TITLE
Implement caching and batching for performance

### DIFF
--- a/packages/ilmomasiina-backend/src/routes/admin/events/createEvent.ts
+++ b/packages/ilmomasiina-backend/src/routes/admin/events/createEvent.ts
@@ -7,7 +7,8 @@ import { getSequelize } from "../../../models";
 import { Event } from "../../../models/event";
 import { Question } from "../../../models/question";
 import { Quota } from "../../../models/quota";
-import { eventDetailsForAdmin } from "../../events/getEventDetails";
+import { basicEventInfoCached, eventDetailsForAdmin, eventDetailsForUserCached } from "../../events/getEventDetails";
+import { eventsListForUserCached } from "../../events/getEventsList";
 import { toDate } from "../../utils";
 
 export default async function createEvent(
@@ -56,6 +57,10 @@ export default async function createEvent(
 
     return created;
   });
+
+  eventsListForUserCached.invalidate();
+  basicEventInfoCached.invalidate();
+  eventDetailsForUserCached.invalidate();
 
   const eventDetails = await eventDetailsForAdmin(event.id);
 

--- a/packages/ilmomasiina-backend/src/routes/admin/events/deleteEvent.ts
+++ b/packages/ilmomasiina-backend/src/routes/admin/events/deleteEvent.ts
@@ -2,24 +2,33 @@ import { FastifyReply, FastifyRequest } from "fastify";
 
 import type { AdminEventPathParams } from "@tietokilta/ilmomasiina-models";
 import { AuditEvent } from "@tietokilta/ilmomasiina-models";
+import { getSequelize } from "../../../models";
 import { Event } from "../../../models/event";
+import { basicEventInfoCached, eventDetailsForUserCached } from "../../events/getEventDetails";
+import { eventsListForUserCached } from "../../events/getEventsList";
 
 export default async function deleteEvent(
   request: FastifyRequest<{ Params: AdminEventPathParams }>,
   response: FastifyReply,
 ): Promise<void> {
-  const event = await Event.findByPk(request.params.id);
-  if (event === null) {
-    response.notFound("No event found with id");
-    return;
-  }
+  await getSequelize().transaction(async (transaction) => {
+    const event = await Event.findByPk(request.params.id);
+    if (event === null) {
+      response.notFound("No event found with id");
+      return;
+    }
 
-  // Delete the DB object
-  await event?.destroy();
+    // Delete the DB object
+    await event?.destroy({ transaction });
 
-  if (event) {
-    await request.logEvent(AuditEvent.DELETE_EVENT, { event });
-  }
+    if (event) {
+      await request.logEvent(AuditEvent.DELETE_EVENT, { event, transaction });
+    }
+  });
+
+  eventsListForUserCached.invalidate();
+  basicEventInfoCached.invalidate();
+  eventDetailsForUserCached.invalidate();
 
   response.status(204);
 }

--- a/packages/ilmomasiina-backend/src/routes/admin/events/updateEvent.ts
+++ b/packages/ilmomasiina-backend/src/routes/admin/events/updateEvent.ts
@@ -14,7 +14,8 @@ import { getSequelize } from "../../../models";
 import { Event } from "../../../models/event";
 import { Question } from "../../../models/question";
 import { Quota } from "../../../models/quota";
-import { eventDetailsForAdmin } from "../../events/getEventDetails";
+import { basicEventInfoCached, eventDetailsForAdmin, eventDetailsForUserCached } from "../../events/getEventDetails";
+import { eventsListForUserCached } from "../../events/getEventsList";
 import { refreshSignupPositions } from "../../signups/computeSignupPosition";
 import { toDate } from "../../utils";
 import { EditConflict } from "./errors";
@@ -174,6 +175,10 @@ export default async function updateEvent(
 
     await request.logEvent(action, { event, transaction });
   });
+
+  eventsListForUserCached.invalidate();
+  basicEventInfoCached.invalidate();
+  eventDetailsForUserCached.invalidate();
 
   const updatedEvent = await eventDetailsForAdmin(request.params.id);
 

--- a/packages/ilmomasiina-backend/src/routes/events/getEventsList.ts
+++ b/packages/ilmomasiina-backend/src/routes/events/getEventsList.ts
@@ -7,6 +7,7 @@ import { Event } from "../../models/event";
 import { Quota } from "../../models/quota";
 import { Signup } from "../../models/signup";
 import { ascNullsFirst } from "../../models/util";
+import createCache from "../../util/cache";
 import { InitialSetupNeeded, isInitialSetupDone } from "../admin/users/createInitialUser";
 import { StringifyApi } from "../utils";
 
@@ -20,6 +21,43 @@ function eventOrder(): Order {
   ];
 }
 
+export const eventsListForUserCached = createCache({
+  maxAgeMs: 1000,
+  maxPendingAgeMs: 2000,
+  async get(category?: string) {
+    const where = category ? { category } : {};
+
+    const events = await Event.scope("user").findAll({
+      attributes: eventListEventAttrs,
+      where: { listed: true, ...where },
+      // Include quotas of event and count of signups
+      include: [
+        {
+          model: Quota,
+          attributes: ["id", "title", "size", [fn("COUNT", col("quotas->signups.id")), "signupCount"]],
+          include: [
+            {
+              model: Signup.scope("active"),
+              required: false,
+              attributes: [],
+            },
+          ],
+        },
+      ],
+      group: [col("event.id"), col("quotas.id")],
+      order: eventOrder(),
+    });
+
+    return events.map((event) => ({
+      ...event.get({ plain: true }),
+      quotas: event.quotas!.map((quota) => ({
+        ...quota.get({ plain: true }),
+        signupCount: Number(quota.signupCount),
+      })),
+    }));
+  },
+});
+
 export async function getEventsListForUser(
   this: FastifyInstance<any, any, any, any, any>,
   request: FastifyRequest<{ Querystring: EventListQuery }>,
@@ -30,38 +68,11 @@ export async function getEventsListForUser(
     throw new InitialSetupNeeded("Initial setup of Ilmomasiina is needed.");
   }
 
-  const events = await Event.scope("user").findAll({
-    attributes: eventListEventAttrs,
-    where: { listed: true, ...request.query },
-    // Include quotas of event and count of signups
-    include: [
-      {
-        model: Quota,
-        attributes: ["id", "title", "size", [fn("COUNT", col("quotas->signups.id")), "signupCount"]],
-        include: [
-          {
-            model: Signup.scope("active"),
-            required: false,
-            attributes: [],
-          },
-        ],
-      },
-    ],
-    group: [col("event.id"), col("quotas.id")],
-    order: eventOrder(),
-  });
-
-  const res = events.map((event) => ({
-    ...event.get({ plain: true }),
-    quotas: event.quotas!.map((quota) => ({
-      ...quota.get({ plain: true }),
-      signupCount: Number(quota.signupCount),
-    })),
-  }));
-
+  const res = await eventsListForUserCached(request.query.category);
   reply.status(200);
   return res as StringifyApi<typeof res>;
 }
+
 export async function getEventsListForAdmin(
   request: FastifyRequest<{ Querystring: EventListQuery }>,
   reply: FastifyReply,

--- a/packages/ilmomasiina-backend/src/routes/signups/createNewSignup.ts
+++ b/packages/ilmomasiina-backend/src/routes/signups/createNewSignup.ts
@@ -43,7 +43,10 @@ export default async function createSignup(
 
   // Create the signup.
   const newSignup = await Signup.create({ quotaId: request.body.quotaId });
-  await refreshSignupPositions(quota.event);
+
+  // Refresh signup positions. Ignore errors, but wait for this to complete, so that the user
+  // gets a status on their signup before it being returned.
+  await refreshSignupPositions(quota.event).catch((error) => console.error(error));
 
   const editToken = generateToken(newSignup.id);
 

--- a/packages/ilmomasiina-backend/src/util/cache.ts
+++ b/packages/ilmomasiina-backend/src/util/cache.ts
@@ -1,0 +1,94 @@
+interface Options<A, R> {
+  /** Maximum number of milliseconds since start of call that a result can be reused. */
+  maxAgeMs: number;
+  /** Maximum number of milliseconds since start of call that a pending promise can be reused. */
+  maxPendingAgeMs?: number;
+  /** Maximum number of cache entries to persist. Least recently used entries are evicted. */
+  maxSize?: number;
+  /** If not set to true, the cache will be disabled in testing. */
+  allowTesting?: boolean;
+  /** The actual implementation of the cached function. */
+  get(key: A): Promise<R>;
+}
+
+interface Ongoing<R> {
+  promise: Promise<R>;
+  created: number;
+  state: "running" | "success" | "error";
+}
+
+interface CachedGet<A, R> {
+  (key: A): Promise<R>;
+  invalidate(key?: A): void;
+}
+
+/**
+ * Wraps the `get` function in a cache.
+ *
+ * Calls to the returned function within `maxPendingAgeMs` will reuse the same call to `get`, and the result will be
+ * reused within `maxAgeMs` of the call starting (not returning).
+ *
+ * Only the latest `maxSize` keys are preserved in the cache.
+ */
+export default function createCache<A, R>({
+  maxAgeMs,
+  maxPendingAgeMs = maxAgeMs,
+  maxSize = 128,
+  allowTesting = false,
+  get,
+}: Options<A, R>) {
+  // Disable cache when in testing.
+  if (process.env.NODE_ENV === "test" && !allowTesting) {
+    const dummyGet = ((key: A) => get(key)) as CachedGet<A, R>;
+    dummyGet.invalidate = () => {};
+    return dummyGet;
+  }
+
+  const cache = new Map<A, Ongoing<R>>();
+
+  const cachedGet = (async (key: A) => {
+    const currentGet = cache.get(key);
+
+    // Reuse successful and pending queries as described above.
+    if (
+      currentGet &&
+      ((currentGet.state === "running" && currentGet.created > Date.now() - maxPendingAgeMs) ||
+        (currentGet.state === "success" && currentGet.created > Date.now() - maxAgeMs))
+    ) {
+      return currentGet.promise;
+    }
+
+    const newGet: Ongoing<R> = {
+      promise: get(key).then(
+        (result) => {
+          newGet.state = "success";
+          return result;
+        },
+        (error) => {
+          newGet.state = "error";
+          throw error;
+        },
+      ),
+      created: Date.now(),
+      state: "running",
+    };
+    // Delete, then set, to ensure the key is bumped to the end.
+    cache.delete(key);
+    cache.set(key, newGet);
+
+    // Delete least-recently-used entries.
+    if (cache.size > maxSize) {
+      const extraKeys = Array.from(cache.keys()).slice(0, cache.size - maxSize);
+      for (const extraKey of extraKeys) cache.delete(extraKey);
+    }
+
+    return newGet.promise;
+  }) as CachedGet<A, R>;
+
+  cachedGet.invalidate = (key) => {
+    if (key) cache.delete(key);
+    else cache.clear();
+  };
+
+  return cachedGet;
+}

--- a/packages/ilmomasiina-backend/test/setup.ts
+++ b/packages/ilmomasiina-backend/test/setup.ts
@@ -1,34 +1,52 @@
 import { faker } from "@faker-js/faker";
-import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, TaskBase, vi } from "vitest";
 
 import initApp from "../src/app";
 import EmailService from "../src/mail";
 import setupDatabase, { closeDatabase } from "../src/models";
 import { testUser } from "./testData";
 
-// Common setup for all backend test files: initialize Sequelize & Fastify, tear down at test end.
+const needsDb = (suite: TaskBase) => suite.name.includes("test/routes");
+const needsApi = (suite: TaskBase) => suite.name.includes("test/routes");
 
-beforeAll(async () => {
-  global.sequelize = await setupDatabase();
-  global.server = await initApp();
+// Common setup for all backend test files: initialize Sequelize & Fastify, tear down at test end.
+beforeAll(async (suite) => {
+  if (needsDb(suite)) {
+    global.sequelize = await setupDatabase();
+  } else {
+    global.sequelize = undefined as any;
+  }
+  if (needsApi(suite)) {
+    global.server = await initApp();
+  } else {
+    global.server = undefined as any;
+  }
 });
 afterAll(async () => {
-  await server.close();
-  await closeDatabase();
+  if (sequelize) {
+    await closeDatabase();
+    global.sequelize = undefined as any;
+  }
+  if (server) {
+    await server.close();
+    global.server = undefined as any;
+  }
 });
 
 beforeEach(async () => {
   // Ensure deterministic test data.
   faker.seed(133742069);
 
-  // Delete test data that can conflict between tests.
-  await sequelize.getQueryInterface().bulkDelete("user", {}, { truncate: true, cascade: true } as any);
-  // Event truncation cascades to all other event data:
-  await sequelize.getQueryInterface().bulkDelete("event", {}, { truncate: true, cascade: true } as any);
-  await sequelize.getQueryInterface().bulkDelete("auditlog", {}, { truncate: true, cascade: true } as any);
+  if (sequelize) {
+    // Delete test data that can conflict between tests.
+    await sequelize.getQueryInterface().bulkDelete("user", {}, { truncate: true, cascade: true } as any);
+    // Event truncation cascades to all other event data:
+    await sequelize.getQueryInterface().bulkDelete("event", {}, { truncate: true, cascade: true } as any);
+    await sequelize.getQueryInterface().bulkDelete("auditlog", {}, { truncate: true, cascade: true } as any);
 
-  // Create a test user to ensure full functionality.
-  global.adminUser = await testUser();
+    // Create a test user to ensure full functionality.
+    global.adminUser = await testUser();
+  }
 });
 
 // Mock email sending: ensure no actual email is sent and allow checking for calls.

--- a/packages/ilmomasiina-backend/test/util/cache.test.ts
+++ b/packages/ilmomasiina-backend/test/util/cache.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test, vi } from "vitest";
+
+import createCache from "../../src/util/cache";
+
+describe("createCache", () => {
+  test("returns correct results", async () => {
+    const get = async (key: number) => key + 1;
+    const cache = createCache({ allowTesting: true, maxAgeMs: Infinity, get });
+    expect(await cache(1)).toEqual(2);
+    expect(await cache(39)).toEqual(40);
+  });
+
+  test("does not call get() unnecessarily", () => {
+    const get = vi.fn(async (key: number) => key + 1);
+    const cache = createCache({ allowTesting: true, maxAgeMs: Infinity, get });
+
+    cache(1);
+    cache(2);
+    cache(3);
+    cache(1);
+    cache(1);
+    cache(2);
+    cache(1);
+    expect(get).toBeCalledTimes(3);
+  });
+
+  test("respects maxAge", async () => {
+    let add = 1;
+    const get = vi.fn(async (key: number) => key + add);
+    const cache = createCache({ allowTesting: true, maxAgeMs: 1000, get });
+
+    vi.useFakeTimers();
+
+    expect(await cache(1)).toEqual(2);
+    expect(await cache(1)).toEqual(2);
+    expect(get).toBeCalledTimes(1);
+
+    vi.setSystemTime(Date.now() + 1500);
+
+    add = 2;
+    expect(await cache(1)).toEqual(3);
+    expect(await cache(1)).toEqual(3);
+    expect(get).toBeCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  test("respects maxSize", async () => {
+    let add = 1;
+    const get = vi.fn(async (key: number) => key + add);
+    const cache = createCache({ allowTesting: true, maxAgeMs: Infinity, maxSize: 3, get });
+
+    expect(await cache(1)).toEqual(2);
+    expect(await cache(2)).toEqual(3);
+    expect(await cache(3)).toEqual(4);
+    expect(await cache(4)).toEqual(5);
+    expect(await cache(3)).toEqual(4);
+    expect(await cache(2)).toEqual(3);
+    expect(get).toBeCalledTimes(4);
+
+    add = 2;
+    expect(await cache(1)).toEqual(3);
+    expect(get).toBeCalledTimes(5);
+  });
+
+  test("respects invalidate()", async () => {
+    let add = 1;
+    const get = vi.fn(async (key: number) => key + add);
+    const cache = createCache({ allowTesting: true, maxAgeMs: Infinity, get });
+
+    expect(await cache(1)).toEqual(2);
+    expect(await cache(1)).toEqual(2);
+    expect(get).toBeCalledTimes(1);
+
+    add = 2;
+    cache.invalidate();
+
+    expect(await cache(1)).toEqual(3);
+    expect(await cache(1)).toEqual(3);
+    expect(get).toBeCalledTimes(2);
+  });
+});


### PR DESCRIPTION
- Cache event list and event details DB fetches for users
- Batch recomputing signup statuses/positions

Ran `loadTest.js` on my laptop with ~100 events and ~10k signups generated by `fillDatabase.ts`.

Before:
```
     http_req_duration_events_list.........: avg=1.33s    min=53.44ms  med=1.33s    max=5.1s    p(90)=1.39s    p(95)=1.42s   
     http_req_duration_individual_events...: avg=730.41ms min=457.2ms  med=693.44ms max=2.95s   p(90)=769.92ms p(95)=806.47ms
     http_req_duration_sign_up_to_quota....: avg=2.37s    min=979.54ms med=2.21s    max=3.61s   p(90)=3.41s    p(95)=3.52s   
     http_reqs_events_list.................: 2293   24.494281/s
     http_reqs_individual_events...........: 4166   44.502038/s
     http_reqs_sign_up_to_quota............: 1338   14.292781/s
```

After:
```
     http_req_duration_events_list.........: avg=232.24ms min=5.09ms   med=214.34ms max=1.16s   p(90)=287.86ms p(95)=305.97ms
     http_req_duration_individual_events...: avg=42.53ms  min=868.91µs med=33.08ms  max=2.48s   p(90)=64.8ms   p(95)=101.16ms
     http_req_duration_sign_up_to_quota....: avg=529.02ms min=143.46ms med=489.39ms max=1.54s   p(90)=730.67ms p(95)=753.94ms
     http_reqs_events_list.................: 12948  142.9286/s
     http_reqs_individual_events...........: 70335  776.404317/s
     http_reqs_sign_up_to_quota............: 5757   63.549579/s
```