### PR TITLE
Automatically renew auth token

### DIFF
--- a/packages/ilmomasiina-frontend/src/api.ts
+++ b/packages/ilmomasiina-frontend/src/api.ts
@@ -1,14 +1,12 @@
 import { ApiError, apiFetch, FetchOptions } from "@tietokilta/ilmomasiina-components";
 import { ErrorCode } from "@tietokilta/ilmomasiina-models";
-import { loginExpired, renewLogin } from "./modules/auth/actions";
+import { loginExpired } from "./modules/auth/actions";
 import { AccessToken } from "./modules/auth/types";
 import type { DispatchAction } from "./store/types";
 
 interface AdminApiFetchOptions extends FetchOptions {
   accessToken?: AccessToken;
 }
-
-const RENEW_LOGIN_THRESHOLD = 5 * 60 * 1000;
 
 /** Wrapper for apiFetch that checks for Unauthenticated responses and dispatches a loginExpired
  * action if necessary.
@@ -22,10 +20,6 @@ export default async function adminApiFetch<T = unknown>(
     const { accessToken } = opts;
     if (!accessToken) {
       throw new ApiError(401, { isUnauthenticated: true });
-    }
-    // Renew token asynchronously if it's expiring soon
-    if (Date.now() > accessToken.expiresAt - RENEW_LOGIN_THRESHOLD) {
-      dispatch(renewLogin(accessToken.token));
     }
     return await apiFetch<T>(uri, {
       ...opts,

--- a/packages/ilmomasiina-frontend/src/containers/AuthProvider.tsx
+++ b/packages/ilmomasiina-frontend/src/containers/AuthProvider.tsx
@@ -1,10 +1,23 @@
-import React, { PropsWithChildren } from "react";
+import React, { PropsWithChildren, useEffect } from "react";
 
 import { AuthContext } from "@tietokilta/ilmomasiina-components";
-import { useTypedSelector } from "../store/reducers";
+import { renewLogin } from "../modules/auth/actions";
+import { useTypedDispatch, useTypedSelector } from "../store/reducers";
+
+const LOGIN_RENEW_INTERVAL = 60 * 1000;
 
 const AuthProvider = ({ children }: PropsWithChildren<{}>) => {
   const auth = useTypedSelector((state) => state.auth);
+  const dispatch = useTypedDispatch();
+
+  useEffect(() => {
+    // Renew login immediately on page load if necessary.
+    dispatch(renewLogin());
+    // Then, check every minute and renew if necessary.
+    const timer = window.setInterval(() => dispatch(renewLogin()), LOGIN_RENEW_INTERVAL);
+    return () => window.clearTimeout(timer);
+  }, [dispatch]);
+
   return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>;
 };
 


### PR DESCRIPTION
Automatically renews the auth token whenever logged in and having the page loaded.

Perhaps a slightly cleaner option than just extending the validity. I think 30 mins to an hour of validity might still be warranted even with this setup, perhaps not 3h.