### PR TITLE
fix: improve expired token handling

### DIFF
--- a/packages/ilmomasiina-frontend/src/containers/requireAuth.tsx
+++ b/packages/ilmomasiina-frontend/src/containers/requireAuth.tsx
@@ -1,8 +1,6 @@
 import React, { ComponentType, useEffect } from "react";
 
-import { toast } from "react-toastify";
-
-import { redirectToLogin } from "../modules/auth/actions";
+import { loginExpired, redirectToLogin } from "../modules/auth/actions";
 import { useTypedDispatch, useTypedSelector } from "../store/reducers";
 
 export default function requireAuth<P extends {}>(WrappedComponent: ComponentType<P>) {
@@ -16,11 +14,8 @@ export default function requireAuth<P extends {}>(WrappedComponent: ComponentTyp
 
     useEffect(() => {
       if (expired) {
-        toast.error("Sisäänkirjautumisesi on vanhentunut. Kirjaudu sisään uudelleen.", {
-          autoClose: 10000,
-        });
-      }
-      if (needLogin) {
+        dispatch(loginExpired());
+      } else if (needLogin) {
         dispatch(redirectToLogin());
       }
     }, [needLogin, expired, dispatch]);

--- a/packages/ilmomasiina-frontend/src/modules/auth/actions.ts
+++ b/packages/ilmomasiina-frontend/src/modules/auth/actions.ts
@@ -1,8 +1,8 @@
 import { push } from "connected-react-router";
 import { toast } from "react-toastify";
 
-import { ApiError, apiFetch } from "@tietokilta/ilmomasiina-components";
-import { AdminLoginResponse, ErrorCode } from "@tietokilta/ilmomasiina-models";
+import { apiFetch } from "@tietokilta/ilmomasiina-components";
+import { AdminLoginResponse } from "@tietokilta/ilmomasiina-models";
 import i18n from "../../i18n";
 import appPaths from "../../paths";
 import type { DispatchAction, GetState } from "../../store/types";
@@ -87,7 +87,8 @@ const RENEW_LOGIN_THRESHOLD = 5 * 60 * 1000;
 
 export const renewLogin = () => async (dispatch: DispatchAction, getState: GetState) => {
   const { accessToken } = getState().auth;
-  if (!accessToken || Date.now() < accessToken.expiresAt - RENEW_LOGIN_THRESHOLD) return;
+  if (!accessToken || Date.now() < accessToken.expiresAt - RENEW_LOGIN_THRESHOLD || Date.now() > accessToken.expiresAt)
+    return;
 
   try {
     if (accessToken) {
@@ -101,10 +102,6 @@ export const renewLogin = () => async (dispatch: DispatchAction, getState: GetSt
       }
     }
   } catch (err) {
-    if (err instanceof ApiError && err.code === ErrorCode.BAD_SESSION) {
-      dispatch(loginExpired());
-    } else {
-      throw err;
-    }
+    // Ignore errors from login renewal - loginExpired() will trigger via requireAuth.
   }
 };


### PR DESCRIPTION
Fixes the regression from #141 where the app would redirect the user to the login page when opening it after inactivity, and improves handling of expired tokens.

- The app no longer tries to renew expired tokens at all
- Errors from token renewal are silently ignored, relying on the admin route `requireAuth` wrapper to trigger `loginExpired` when necessary