### PR TITLE
fix: make links detectable with black $primary

### DIFF
--- a/packages/ilmomasiina-components/src/styles/_definitions.scss
+++ b/packages/ilmomasiina-components/src/styles/_definitions.scss
@@ -6,14 +6,15 @@
 // For Bootstrap components, the overrides are made in ilmomasiina-frontend/src/styles/app.scss.
 // If you want to override more colors, you'll also need to add them to the @use there.
 
-// The colors here are inherited from Athene's code and will remain in place while mainline
-// Ilmomasiina uses Bootstrap 4.
-
 $primary: #0a0d10 !default;
 $secondary: #0a0d10 !default;
 $red: #d74949 !default; // further assigned to $danger by Bootstrap
 $green: #319236 !default; // further assigned to $success by Bootstrap
 $text-muted: #888 !default;
+
+// Links are impossible to see with Tietokilta's black $primary.
+// You can disable this if you use something light.
+$force-link-underline: true !default;
 
 // Additional colors, only used by Ilmomasiina's SCSS.
 

--- a/packages/ilmomasiina-frontend/src/styles/app.scss
+++ b/packages/ilmomasiina-frontend/src/styles/app.scss
@@ -49,6 +49,12 @@ footer {
 
 // Typography
 
+@if $force-link-underline {
+  a {
+    text-decoration: underline;
+  }
+}
+
 h1 {
   font-weight: 800;
   text-transform: uppercase;


### PR DESCRIPTION
After #136, links are impossible to see with our all-black palette.

This adds the option to force-enable link underlines in `_definitions.scss` to match what we do at tietokilta.fi.