### PR TITLE
fix: Hide quotas for events without a signup

### DIFF
--- a/packages/ilmomasiina-components/src/routes/Events/components/TableRow.tsx
+++ b/packages/ilmomasiina-components/src/routes/Events/components/TableRow.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react";
 
 import { useTranslation } from "react-i18next";
 
-import { SignupStateText } from "../../../utils/signupStateText";
+import { SignupState, SignupStateText } from "../../../utils/signupStateText";
 
 type Props = {
   className: string;
@@ -27,12 +27,14 @@ const TableRow = ({ className, title, date, signupStatus, signupCount, quotaSize
         <span className="ilmo--desktop-only">{signupStatus?.shortLabel}</span>
         <span className="ilmo--mobile-only">{signupStatus?.fullLabel || signupStatus?.shortLabel}</span>
       </td>
-      <td key="signups" className="ilmo--signup-count">
-        {signupCount !== undefined && <span className="ilmo--mobile-only">{`${t("events.signupCount")} `}</span>}
-        {signupCount}
-        {quotaSize && <>&ensp;/&ensp;</>}
-        {quotaSize || ""}
-      </td>
+      {signupStatus?.state.state !== SignupState.disabled && (
+        <td key="signups" className="ilmo--signup-count">
+          {signupCount !== undefined && <span className="ilmo--mobile-only">{`${t("events.signupCount")} `}</span>}
+          {signupCount}
+          {quotaSize && <>&ensp;/&ensp;</>}
+          {quotaSize || ""}
+        </td>
+      )}
     </tr>
   );
 };

--- a/packages/ilmomasiina-components/src/routes/SingleEvent/components/QuotaStatus.tsx
+++ b/packages/ilmomasiina-components/src/routes/SingleEvent/components/QuotaStatus.tsx
@@ -9,6 +9,8 @@ import QuotaProgress from "./QuotaProgress";
 const QuotaStatus = () => {
   const { event, signupsByQuota } = useSingleEventContext();
   const { t } = useTranslation();
+
+  if (!signupsByQuota?.length) return null;
   return (
     <div className="ilmo--side-widget">
       <h3>{t("singleEvent.quotaCounts.title")}</h3>

--- a/packages/ilmomasiina-components/src/routes/SingleEvent/components/SignupButton.tsx
+++ b/packages/ilmomasiina-components/src/routes/SingleEvent/components/SignupButton.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from "../../../config/router";
 import { usePaths } from "../../../contexts/paths";
 import { beginSignup, useSingleEventContext } from "../../../modules/singleEvent";
 import { errorDesc } from "../../../utils/errorMessage";
-import { signupState, useSignupStateText } from "../../../utils/signupStateText";
+import { SignupState, signupState, useSignupStateText } from "../../../utils/signupStateText";
 
 // Show the countdown one minute before opening the signup.
 const COUNTDOWN_DURATION = 60 * 1000;
@@ -68,22 +68,27 @@ const SignupButton = ({ isOpen, isClosed, seconds, total }: SignupButtonProps) =
           <span style={{ color: "green" }}>{` (${seconds} s)`}</span>
         )}
       </p>
-      {preview ? (
-        <Button onClick={() => preview.setPreviewingForm(true)}>{t("singleEvent.signupButton.preview")}</Button>
-      ) : (
-        quotas.map((quota) => (
-          <Button
-            key={quota.id}
-            type="button"
-            variant="secondary"
-            disabled={!isOpen || submitting}
-            className="ilmo--signup-button"
-            onClick={() => onClick(quota.id)}
-          >
-            {isOnly ? t("singleEvent.signupButton.singleQuota") : t("singleEvent.signupButton", { quota: quota.title })}
-          </Button>
-        ))
-      )}
+      {
+        // eslint-disable-next-line no-nested-ternary
+        eventState.state === SignupState.disabled ? null : preview ? (
+          <Button onClick={() => preview.setPreviewingForm(true)}>{t("singleEvent.signupButton.preview")}</Button>
+        ) : (
+          quotas.map((quota) => (
+            <Button
+              key={quota.id}
+              type="button"
+              variant="secondary"
+              disabled={!isOpen || submitting}
+              className="ilmo--signup-button"
+              onClick={() => onClick(quota.id)}
+            >
+              {isOnly
+                ? t("singleEvent.signupButton.singleQuota")
+                : t("singleEvent.signupButton", { quota: quota.title })}
+            </Button>
+          ))
+        )
+      }
     </div>
   );
 };

--- a/packages/ilmomasiina-components/src/utils/dateFormat.ts
+++ b/packages/ilmomasiina-components/src/utils/dateFormat.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { useTranslation } from "react-i18next";
 
@@ -8,54 +8,70 @@ import { timezone } from "../config";
 export function useEventDateFormatter() {
   const { t } = useTranslation();
   const locale = t("dateFormat.locale");
-  return new Intl.DateTimeFormat(locale, {
-    day: "numeric",
-    month: "numeric",
-    year: "numeric",
-    hour12: false,
-    timeZone: timezone(),
-  });
+  return useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        day: "numeric",
+        month: "numeric",
+        year: "numeric",
+        hour12: false,
+        timeZone: timezone(),
+      }),
+    [locale],
+  );
 }
 
 /** Returns a formatter for event datetimes like "su 31.12.2024 23:59". */
 export function useEventDateTimeFormatter() {
   const { t } = useTranslation();
   const locale = t("dateFormat.locale");
-  return new Intl.DateTimeFormat(locale, {
-    weekday: "short",
-    day: "numeric",
-    month: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    hour12: false,
-    timeZone: timezone(),
-  });
+  return useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        weekday: "short",
+        day: "numeric",
+        month: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        hour12: false,
+        timeZone: timezone(),
+      }),
+    [locale],
+  );
 }
 
 /** Returns a formatter for seconds-accurate datetimes like "31.12.2024 23:59:59". */
 export function useActionDateTimeFormatter() {
   const { t } = useTranslation();
   const locale = t("dateFormat.locale");
-  return new Intl.DateTimeFormat(locale, {
-    day: "numeric",
-    month: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
-    hour12: false,
-    timeZone: timezone(),
-  });
+  return useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        day: "numeric",
+        month: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        second: "numeric",
+        hour12: false,
+        timeZone: timezone(),
+      }),
+    [locale],
+  );
 }
 
 /** Returns a formatter for the milliseconds of a time. */
 export function useMillisecondsDateTimeFormatter() {
   const { t } = useTranslation();
   const locale = t("dateFormat.locale");
-  return new Intl.DateTimeFormat(locale, {
-    fractionalSecondDigits: 3,
-  });
+  return useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        fractionalSecondDigits: 3,
+      }),
+    [locale],
+  );
 }
 
 /** Returns a formatter for seconds-accurate datetimes like "31.12.2024 23:59:59". */

--- a/packages/ilmomasiina-components/src/utils/eventListUtils.ts
+++ b/packages/ilmomasiina-components/src/utils/eventListUtils.ts
@@ -8,7 +8,7 @@ import type {
   UserEventListItem,
   UserEventListResponse,
 } from "@tietokilta/ilmomasiina-models";
-import { signupState, SignupStateInfo } from "./signupStateText";
+import { SignupState, signupState, SignupStateInfo } from "./signupStateText";
 
 export interface EventTableOptions {
   /** If true, quotas are not placed on separate rows. */
@@ -57,8 +57,8 @@ export function eventToRows(event: UserEventListItem, { compact }: EventTableOpt
     },
   ];
 
-  // We're done for compact format
-  if (compact) return rows;
+  // We're done for compact format and events without a signup
+  if (compact || state.state === SignupState.disabled) return rows;
 
   // Multiple quotas go on their own rows
   if (quotas.length > 1) {

--- a/packages/ilmomasiina-components/src/utils/signupStateText.ts
+++ b/packages/ilmomasiina-components/src/utils/signupStateText.ts
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { useTranslation } from "react-i18next";
 
 import { useEventDateTimeFormatter } from "./dateFormat";
@@ -36,6 +38,7 @@ export function signupState(starts: string | null, closes: string | null): Signu
 }
 
 export interface SignupStateText {
+  state: SignupStateInfo;
   class: string;
   shortLabel: string;
   fullLabel?: string;
@@ -45,43 +48,49 @@ export function useSignupStateText(state: SignupStateInfo): SignupStateText {
   const { t } = useTranslation();
   const eventDateFormat = useEventDateTimeFormatter();
 
-  switch (state.state) {
-    case SignupState.disabled:
-      return {
-        shortLabel: t("signupState.disabled"),
-        class: "ilmo--signup-disabled",
-      };
-    case SignupState.not_opened:
-      return {
-        shortLabel: t("signupState.notOpened.short", {
-          date: eventDateFormat.format(new Date(state.opens)),
-        }),
-        fullLabel: t("signupState.notOpened", {
-          date: eventDateFormat.format(new Date(state.opens)),
-        }),
-        class: "ilmo--signup-not-opened",
-      };
-    case SignupState.open:
-      return {
-        shortLabel: t("signupState.open.short", {
-          date: eventDateFormat.format(new Date(state.closes)),
-        }),
-        fullLabel: t("signupState.open", {
-          date: eventDateFormat.format(new Date(state.closes)),
-        }),
-        class: "ilmo--signup-opened",
-      };
-    case SignupState.closed:
-      return {
-        shortLabel: t("signupState.closed.short", {
-          date: eventDateFormat.format(new Date(state.closed)),
-        }),
-        fullLabel: t("signupState.closed", {
-          date: eventDateFormat.format(new Date(state.closed)),
-        }),
-        class: "ilmo--signup-closed",
-      };
-    default:
-      throw new Error("invalid state");
-  }
+  return useMemo(() => {
+    switch (state.state) {
+      case SignupState.disabled:
+        return {
+          state,
+          shortLabel: t("signupState.disabled"),
+          class: "ilmo--signup-disabled",
+        };
+      case SignupState.not_opened:
+        return {
+          state,
+          shortLabel: t("signupState.notOpened.short", {
+            date: eventDateFormat.format(new Date(state.opens)),
+          }),
+          fullLabel: t("signupState.notOpened", {
+            date: eventDateFormat.format(new Date(state.opens)),
+          }),
+          class: "ilmo--signup-not-opened",
+        };
+      case SignupState.open:
+        return {
+          state,
+          shortLabel: t("signupState.open.short", {
+            date: eventDateFormat.format(new Date(state.closes)),
+          }),
+          fullLabel: t("signupState.open", {
+            date: eventDateFormat.format(new Date(state.closes)),
+          }),
+          class: "ilmo--signup-opened",
+        };
+      case SignupState.closed:
+        return {
+          state,
+          shortLabel: t("signupState.closed.short", {
+            date: eventDateFormat.format(new Date(state.closed)),
+          }),
+          fullLabel: t("signupState.closed", {
+            date: eventDateFormat.format(new Date(state.closed)),
+          }),
+          class: "ilmo--signup-closed",
+        };
+      default:
+        throw new Error("invalid state");
+    }
+  }, [state, t, eventDateFormat]);
 }


### PR DESCRIPTION
If signups are disabled for an event: 
- Always hides quotas and signup counts in the event list
- Hides signup buttons
- Hides empty quotas in public signup list and progress bars
    - Nonempty quotas are shown, in case Ilmomasiina is ever used with an event only fillable by admins