### PR TITLE
fix: add missing transaction params to queries

### DIFF
--- a/packages/ilmomasiina-backend/src/routes/admin/events/deleteEvent.ts
+++ b/packages/ilmomasiina-backend/src/routes/admin/events/deleteEvent.ts
@@ -12,7 +12,7 @@ export default async function deleteEvent(
   response: FastifyReply,
 ): Promise<void> {
   await getSequelize().transaction(async (transaction) => {
-    const event = await Event.findByPk(request.params.id);
+    const event = await Event.findByPk(request.params.id, { transaction });
     if (event === null) {
       response.notFound("No event found with id");
       return;

--- a/packages/ilmomasiina-backend/src/routes/signups/createNewSignup.ts
+++ b/packages/ilmomasiina-backend/src/routes/signups/createNewSignup.ts
@@ -37,6 +37,7 @@ export default async function createSignup(
           attributes: ["id", "registrationStartDate", "registrationEndDate", "openQuotaSize"],
         },
       ],
+      transaction,
     });
 
     // Do some validation.
@@ -49,7 +50,7 @@ export default async function createSignup(
     }
 
     // Create the signup.
-    const signup = await Signup.create({ quotaId: request.body.quotaId });
+    const signup = await Signup.create({ quotaId: request.body.quotaId }, { transaction });
 
     // Create an audit log event
     await request.logEvent(AuditEvent.CREATE_SIGNUP, { signup, transaction });


### PR DESCRIPTION
Cherry-picked from FK fork, Supersedes #163 