### PR TITLE
fix: don't html escape localized strings in backend

### DIFF
--- a/packages/ilmomasiina-backend/src/i18n.ts
+++ b/packages/ilmomasiina-backend/src/i18n.ts
@@ -18,6 +18,10 @@ i18n.init({
     fi,
     en,
   },
+
+  interpolation: {
+    escapeValue: false
+  }
 });
 
 export default i18n;


### PR DESCRIPTION
untested