### PR TITLE
Edit signup email takes to juhlavuosi.fi for juhlavuosi events

### DIFF
--- a/packages/ilmomasiina-backend/src/config.ts
+++ b/packages/ilmomasiina-backend/src/config.ts
@@ -225,8 +225,18 @@ export function eventDetailsUrl({ slug, lang }: { slug: string; lang: string }) 
   return config.eventDetailsUrl.replace(/\{slug\}/g, slug).replace(/\{lang\}/g, lang);
 }
 
-export function editSignupUrl({ id, editToken, lang }: { id: string; editToken: string; lang: string }) {
-  return config.editSignupUrl
+export function editSignupUrl({
+  id,
+  editToken,
+  lang,
+  base_url,
+}: {
+  id: string;
+  editToken: string;
+  lang: string;
+  base_url?: string;
+}) {
+  return (base_url || config.editSignupUrl)
     .replace(/\{id\}/g, id)
     .replace(/\{editToken\}/g, editToken)
     .replace(/\{lang\}/g, lang);

--- a/packages/ilmomasiina-backend/src/mail/signupConfirmation.ts
+++ b/packages/ilmomasiina-backend/src/mail/signupConfirmation.ts
@@ -37,7 +37,19 @@ export default async function sendSignupConfirmationMail(
   const date = event.date && moment(event.date).tz(config.timezone).format(dateFormat);
 
   const editToken = generateToken(signup.id);
-  const cancelLink = editSignupUrl({ id: signup.id, editToken, lang: signup.language || config.defaultLanguage });
+  const cancelLink =
+    event.category === "Juhlavuosi"
+      ? editSignupUrl({
+          id: signup.id,
+          editToken,
+          lang: signup.language || config.defaultLanguage,
+          base_url: "https://juhlavuosi.fi/{lang}/signups/{id}/{editToken}",
+        })
+      : editSignupUrl({
+          id: signup.id,
+          editToken,
+          lang: signup.language || config.defaultLanguage,
+        });
 
   const params = {
     name: fullName,


### PR DESCRIPTION
Add a temporary redirect of juhlavuosievents to juhlavuosi.fi instead of using the env url.