### PR TITLE
Feat: set document title on pages

### DIFF
--- a/packages/ilmomasiina-frontend/src/routes/404/PageNotFound.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/404/PageNotFound.tsx
@@ -3,10 +3,15 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
+import branding from "../../branding";
 import paths from "../../paths";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 
 const PageNotFound = () => {
   const { t } = useTranslation();
+
+  useDocumentTitle(`${t("errors.404.title")} - ${branding.headerTitleShort}`);
+
   return (
     <div className="ilmo--status-container">
       <h1>{t("errors.404.title")}</h1>

--- a/packages/ilmomasiina-frontend/src/routes/AdminEventsList/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/AdminEventsList/index.tsx
@@ -5,18 +5,22 @@ import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { errorDesc, errorTitle } from "@tietokilta/ilmomasiina-client";
+import branding from "../../branding";
 import LinkButton from "../../components/LinkButton";
 import requireAuth from "../../containers/requireAuth";
 import type { TKey } from "../../i18n";
 import useStore from "../../modules/store";
 import paths from "../../paths";
 import { isEventInPast } from "../../utils/eventState";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 import AdminEventListItem from "./AdminEventListItem";
 
 const AdminEventsList = () => {
   const { events, loadError, getAdminEvents, resetState } = useStore((state) => state.adminEvents);
   const [showPast, setShowPast] = useState(false);
   const { t } = useTranslation();
+
+  useDocumentTitle(`${t("adminEvents.title")} - ${branding.headerTitleShort}`);
 
   const togglePast = useCallback((evt: BaseSyntheticEvent) => {
     evt.preventDefault();

--- a/packages/ilmomasiina-frontend/src/routes/AdminUsers/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/AdminUsers/index.tsx
@@ -5,10 +5,12 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { errorDesc, errorTitle } from "@tietokilta/ilmomasiina-client";
+import branding from "../../branding";
 import requireAuth from "../../containers/requireAuth";
 import type { TKey } from "../../i18n";
 import useStore from "../../modules/store";
 import paths from "../../paths";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 import AdminUserListItem from "./AdminUserListItem";
 import ChangePasswordForm from "./ChangePasswordForm";
 import UserForm from "./UserForm";
@@ -16,6 +18,8 @@ import UserForm from "./UserForm";
 const AdminUsersList = () => {
   const { users, loadError, getUsers, resetState } = useStore((state) => state.adminUsers);
   const { t } = useTranslation();
+
+  useDocumentTitle(`${t("adminUsers.title")} - ${branding.headerTitleShort}`);
 
   useEffect(() => {
     getUsers();

--- a/packages/ilmomasiina-frontend/src/routes/AuditLog/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/AuditLog/index.tsx
@@ -5,10 +5,12 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { errorDesc } from "@tietokilta/ilmomasiina-client";
+import branding from "../../branding";
 import requireAuth from "../../containers/requireAuth";
 import type { TKey } from "../../i18n";
 import useStore from "../../modules/store";
 import paths from "../../paths";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 import AuditLogActionFilter from "./AuditLogActionFilter";
 import AuditLogFilter from "./AuditLogFilter";
 import AuditLogItem from "./AuditLogItem";
@@ -19,6 +21,8 @@ import "./AuditLog.scss";
 const AuditLog = () => {
   const { auditLog, loadError, getAuditLogs, resetState } = useStore((state) => state.auditLog);
   const { t } = useTranslation();
+
+  useDocumentTitle(`${t("auditLog.title")} - ${branding.headerTitleShort}`);
 
   useEffect(() => {
     getAuditLogs({

--- a/packages/ilmomasiina-frontend/src/routes/EditSignup/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/EditSignup/index.tsx
@@ -5,15 +5,30 @@ import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
 import { EditSignupProvider, errorDesc, errorTitle, useEditSignupContext } from "@tietokilta/ilmomasiina-client";
+import branding from "../../branding";
 import type { TKey } from "../../i18n";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 import EditForm from "./components/EditForm";
 import NarrowContainer from "./components/NarrowContainer";
 
 import "./EditSignup.scss";
 
 const EditSignupView = () => {
-  const { error, pending } = useEditSignupContext();
+  const { error, pending, event, signup, editToken } = useEditSignupContext();
   const { t } = useTranslation();
+
+  // Determine the appropriate title based on the context
+  const getTitle = () => {
+    if (editToken && signup) {
+      return t("editSignup.title.edit");
+    }
+    if (event) {
+      return t("editSignup.title.signup");
+    }
+    return t("events.title");
+  };
+
+  useDocumentTitle(`${getTitle()} - ${branding.headerTitleShort}`);
 
   if (error) {
     return (

--- a/packages/ilmomasiina-frontend/src/routes/Editor/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Editor/index.tsx
@@ -5,10 +5,12 @@ import { useTranslation } from "react-i18next";
 import { Link, useParams } from "react-router-dom";
 
 import { errorDesc, errorTitle } from "@tietokilta/ilmomasiina-client";
+import branding from "../../branding";
 import requireAuth from "../../containers/requireAuth";
 import type { TKey } from "../../i18n";
 import useStore from "../../modules/store";
 import paths from "../../paths";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 import EditForm from "./components/EditForm";
 
 import "./Editor.scss";
@@ -24,6 +26,8 @@ const Editor = ({ copy = false }: Props) => {
 
   const urlEventId = useParams<"id">().id!;
   const urlIsNew = urlEventId === "new";
+
+  useDocumentTitle(`${urlIsNew ? t("editor.title.new") : t("editor.title.edit")} - ${branding.headerTitleShort}`);
 
   useEffect(() => {
     if (urlIsNew) {

--- a/packages/ilmomasiina-frontend/src/routes/EventList/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/EventList/index.tsx
@@ -13,10 +13,12 @@ import {
 } from "@tietokilta/ilmomasiina-client";
 import { EventRow, eventsToRows, QuotaRow } from "@tietokilta/ilmomasiina-client/dist/utils/eventListUtils";
 import { ErrorCode } from "@tietokilta/ilmomasiina-models";
+import branding from "../../branding";
 import { TKey } from "../../i18n";
 import paths from "../../paths";
 import { useEventDateFormatter } from "../../utils/dateFormat";
 import { useSignupStateText } from "../../utils/signupStateText";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 import TableRow from "./components/TableRow";
 
 import "./EventList.scss";
@@ -51,6 +53,8 @@ const ListQuotaRow = ({ row: { type, title, signupCount, quotaSize } }: { row: Q
 const EventListView = () => {
   const { localizedEvents: events, error, pending } = useEventListContext();
   const { t } = useTranslation();
+
+  useDocumentTitle(`${t("events.title")} - ${branding.headerTitleShort}`);
 
   const tableRows = useMemo(() => eventsToRows(events ?? []).filter((row) => row.type !== "waitlist"), [events]);
 

--- a/packages/ilmomasiina-frontend/src/routes/InitialSetup/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/InitialSetup/index.tsx
@@ -13,10 +13,10 @@ import i18n, { TKey } from "../../i18n";
 import { loginToast } from "../../modules/auth";
 import useStore from "../../modules/store";
 import paths from "../../paths";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 import useEvent from "../../utils/useEvent";
 
 import "./InitialSetup.scss";
-import useDocumentTitle from "src/utils/useDocumentTitle";
 
 type FormData = {
   email: string;

--- a/packages/ilmomasiina-frontend/src/routes/InitialSetup/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/InitialSetup/index.tsx
@@ -16,6 +16,7 @@ import paths from "../../paths";
 import useEvent from "../../utils/useEvent";
 
 import "./InitialSetup.scss";
+import useDocumentTitle from "src/utils/useDocumentTitle";
 
 type FormData = {
   email: string;
@@ -55,6 +56,8 @@ const InitialSetup = () => {
   const { createInitialUser } = useStore((state) => state.auth);
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  useDocumentTitle(`${t("initialSetup.title")} - ${branding.headerTitle}`);
 
   const onSubmit = useEvent(async (data: FormData) => {
     const { email, password } = data;

--- a/packages/ilmomasiina-frontend/src/routes/Login/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/Login/index.tsx
@@ -13,6 +13,7 @@ import type { TKey } from "../../i18n";
 import { loginToast } from "../../modules/auth";
 import useStore from "../../modules/store";
 import paths from "../../paths";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 import useEvent from "../../utils/useEvent";
 
 import "./Login.scss";
@@ -31,6 +32,8 @@ const Login = () => {
   const { login } = useStore((state) => state.auth);
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  useDocumentTitle(`${t("login.title")} - ${branding.headerTitleShort}`);
 
   const onSubmit = useEvent(async (data: FormData) => {
     const { email, password } = data;

--- a/packages/ilmomasiina-frontend/src/routes/SingleEvent/index.tsx
+++ b/packages/ilmomasiina-frontend/src/routes/SingleEvent/index.tsx
@@ -5,8 +5,10 @@ import { useTranslation } from "react-i18next";
 import { Link, useParams } from "react-router-dom";
 
 import { errorDesc, errorTitle, SingleEventProvider, useSingleEventContext } from "@tietokilta/ilmomasiina-client";
+import branding from "../../branding";
 import { TKey } from "../../i18n";
 import paths from "../../paths";
+import useDocumentTitle from "../../utils/useDocumentTitle";
 import EventDescription from "./components/EventDescription";
 import QuotaStatus from "./components/QuotaStatus";
 import SignupCountdown from "./components/SignupCountdown";
@@ -17,6 +19,8 @@ import "./SingleEvent.scss";
 const SingleEventView = () => {
   const { localizedEvent: event, signupsByQuota, pending, error } = useSingleEventContext();
   const { t } = useTranslation();
+
+  useDocumentTitle(`${event?.title ?? t("events.title")} - ${branding.headerTitleShort}`);
 
   if (error) {
     return (

--- a/packages/ilmomasiina-frontend/src/utils/useDocumentTitle.ts
+++ b/packages/ilmomasiina-frontend/src/utils/useDocumentTitle.ts
@@ -1,0 +1,29 @@
+import { useLayoutEffect, useRef } from "react";
+
+// Copied from https://usehooks-ts.com/react-hook/use-document-title
+
+type UseDocumentTitleOptions = {
+  preserveTitleOnUnmount?: boolean;
+};
+
+export default function useDocumentTitle(title: string, options: UseDocumentTitleOptions = {}): void {
+  const { preserveTitleOnUnmount = true } = options;
+  const defaultTitle = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    defaultTitle.current = window.document.title;
+  }, []);
+
+  useLayoutEffect(() => {
+    window.document.title = title;
+  }, [title]);
+
+  useLayoutEffect(
+    () => () => {
+      if (!preserveTitleOnUnmount && defaultTitle.current) {
+        window.document.title = defaultTitle.current;
+      }
+    },
+    [preserveTitleOnUnmount],
+  );
+}


### PR DESCRIPTION
Fixes #177 

I copied useDocumentTitle hook from [usehooks-ts](https://usehooks-ts.com/react-hook/use-document-title) to avoid the extra dependency.

The format for all pages is "{page} -{branding.headerTitleShort}"

One thing to consider is the difference between `headerTitle` and `headerTitleShort`. For TiK it's "Tietokillan ilmomasiina" vs. "Ilmomasiina". I chose to use the shorter one in the document title for brevity, but other guilds may have set it as "Ilmomasiina" too.